### PR TITLE
Add code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 
 noinst_LIBRARIES = librtpi.a
-librtpi_a_SOURCES = rtpi.h pi_mutex.c pi_cond.c
+librtpi_a_SOURCES = rtpi.h rtpi_internal.h pi_mutex.c pi_cond.c
 
 bin_PROGRAMS = test
 test_SOURCES = test.c rtpi.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,14 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 
 noinst_LIBRARIES = librtpi.a
-librtpi_a_SOURCES = rtpi.h rtpi_internal.h pi_mutex.c pi_cond.c
+librtpi_a_SOURCES = rtpi.h rtpi_internal.h pi_futex.h pi_mutex.c pi_cond.c
 
-bin_PROGRAMS = test
+bin_PROGRAMS = test tst-cond tst-cond1
 test_SOURCES = test.c rtpi.h
 test_LDADD = librtpi.a -lpthread
+
+tst_cond_SOURCES = tst-cond.c rtpi.h
+tst_cond_LDADD = librtpi.a -lpthread
+
+tst_cond1_SOURCES = tst-cond1.c rtpi.h
+tst_cond1_LDADD = librtpi.a -lpthread

--- a/pi_cond.c
+++ b/pi_cond.c
@@ -152,8 +152,7 @@ int pi_cond_signal(pi_cond_t *cond)
 	pi_mutex_unlock(&cond->priv_mut);
 
 	do {
-		ret = futex_cmp_requeue_PI(cond, id, 0, &cond->priv_mut,
-					   0xffffffff);
+		ret = futex_cmp_requeue_PI(cond, id, 0, &cond->priv_mut);
 		if (ret > 0) {
 			/* Wakeup performed */
 			break;
@@ -196,8 +195,7 @@ int pi_cond_broadcast(pi_cond_t *cond)
 	pi_mutex_unlock(&cond->priv_mut);
 
 	do {
-		ret = futex_cmp_requeue_PI(cond, id, INT_MAX, &cond->priv_mut,
-					   0xffffffff);
+		ret = futex_cmp_requeue_PI(cond, id, INT_MAX, &cond->priv_mut);
 		if (ret >= 0) {
 			/* Wakeup performed */
 			break;

--- a/pi_cond.c
+++ b/pi_cond.c
@@ -33,7 +33,7 @@ int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 		ret = -EINVAL;
 		goto out;
 	}
-
+	memset(cond, 0, sizeof(*cond));
 	if (flags & RTPI_COND_PSHARED) {
 		cond->flags = RTPI_COND_PSHARED;
 	}
@@ -43,7 +43,7 @@ int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 		ret = -EINVAL;
 		goto out;
 	}
-
+	pi_mutex_init(&cond->priv_mut, cond->flags & RTPI_COND_PSHARED);
 	cond->mutex = mutex;
 
 	ret = 0;
@@ -60,12 +60,63 @@ int pi_cond_destroy(pi_cond_t *cond)
 int pi_cond_wait(pi_cond_t *cond)
 {
 	int ret;
+	__u32 wait_id;
+	__u32 futex_id;
 
-	ret = pi_mutex_unlock(cond->mutex);
+	ret = pi_mutex_lock(&cond->priv_mut);
 	if (ret)
 		return ret;
-	ret = futex_wait_requeue_pi(cond, 0, NULL, cond->mutex,
-				    0xffffffff);
+
+	ret = pi_mutex_unlock(cond->mutex);
+	if (ret) {
+		pi_mutex_unlock(&cond->priv_mut);
+		return ret;
+	}
+	cond->pending_wait++;
+	cond->cond++;
+	wait_id = cond->cond;
+	do {
+
+		futex_id = cond->cond;
+		pi_mutex_unlock(&cond->priv_mut);
+
+		ret = futex_wait_requeue_pi(cond, futex_id, NULL,
+					    &cond->priv_mut, 0xffffffff);
+		if (ret < 0) {
+			if (errno == EAGAIN) {
+				/* futex VAL changed between unlock & wait */
+				pi_mutex_lock(&cond->priv_mut);
+				if (cond->wake_id >= wait_id && cond->pending_wake) {
+					/* There is one wakeup pending for us */
+					cond->pending_wake--;
+					cond->pending_wait--;
+					pi_mutex_unlock(&cond->priv_mut);
+					pi_mutex_lock(cond->mutex);
+					ret = 0;
+					break;
+				}
+				/* Reload VAL and try again */
+				continue;
+			} else {
+				/* Error, abort */
+				pi_mutex_lock(&cond->priv_mut);
+				cond->pending_wait--;
+				pi_mutex_unlock(&cond->priv_mut);
+				ret = -errno;
+				break;
+			}
+		}
+		/* All good. Proper wakeup + we own the lock */
+		if (cond->pending_wake) {
+			cond->pending_wait--;
+			cond->pending_wake--;
+			pi_mutex_unlock(&cond->priv_mut);
+			pi_mutex_lock(cond->mutex);
+			ret = 0;
+			break;
+		}
+		/* No wakeup for us, try again… */
+	} while (1);
 	return ret;
 }
 
@@ -77,7 +128,7 @@ int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 	if (ret)
 		return ret;
 	ret = futex_wait_requeue_pi(cond, 0, abstime,
-				    cond->mutex,
+				    &cond->priv_mut,
 				    0);
 	return ret;
 }
@@ -85,21 +136,83 @@ int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 int pi_cond_signal(pi_cond_t *cond)
 {
 	int ret;
+	__u32 id;
 
-	ret = futex_cmp_requeue_PI(cond, 0, 0, cond->mutex,
-				   cond->cond);
-	if (ret < 0)
-		return ret;
+	pi_mutex_lock(&cond->priv_mut);
+
+	if (!cond->pending_wait) {
+		/* No waiters pending */
+		pi_mutex_unlock(&cond->priv_mut);
+		return 0;
+	}
+	cond->cond++;
+	id = cond->cond;
+	cond->wake_id = id;
+	cond->pending_wake++;
+	pi_mutex_unlock(&cond->priv_mut);
+
+	do {
+		ret = futex_cmp_requeue_PI(cond, id, 0, &cond->priv_mut,
+					   0xffffffff);
+		if (ret > 0) {
+			/* Wakeup performed */
+			break;
+
+		} else if (ret == 0) {
+			/* nothing woke up */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->pending_wake--;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else if (errno == EAGAIN) {
+			/* id changed */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->cond++;
+			id = cond->cond;
+			cond->wake_id = id;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else {
+			return -errno;
+		}
+	} while (1);
 	return 0;
 }
 
 int pi_cond_broadcast(pi_cond_t *cond)
 {
 	int ret;
+	__u32 id;
 
-	ret = futex_cmp_requeue_PI(cond, 0, INT_MAX, cond->mutex,
-				   cond->cond);
-	if (ret < 0)
-		return ret;
+	pi_mutex_lock(&cond->priv_mut);
+
+	if (!cond->pending_wait) {
+		/* No waiters pending */
+		pi_mutex_unlock(&cond->priv_mut);
+		return 0;
+	}
+	cond->cond++;
+	id = cond->cond;
+	cond->wake_id = id;
+	cond->pending_wake = cond->pending_wait;
+	pi_mutex_unlock(&cond->priv_mut);
+
+	do {
+		ret = futex_cmp_requeue_PI(cond, id, INT_MAX, &cond->priv_mut,
+					   0xffffffff);
+		if (ret >= 0) {
+			/* Wakeup performed */
+			break;
+
+		} else if (errno == EAGAIN) {
+			/* id changed */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->cond++;
+			id = cond->cond;
+			cond->wake_id = id;
+			cond->pending_wake = cond->pending_wait;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else {
+			return ret;
+		}
+	} while (1);
 	return 0;
 }

--- a/pi_cond.c
+++ b/pi_cond.c
@@ -2,7 +2,7 @@
 // Copyright © 2018 VMware, Inc. All Rights Reserved.
 
 #include <stdio.h>
-#include "rtpi.h"
+#include "rtpi_internal.h"
 
 /*
  * This wrapper for early library validation only.
@@ -10,6 +10,17 @@
  *       Base this on the older version of the condvar, with the patch from
  *       Dinakar and Darren to enable priority fifo wakeup order.
  */
+
+pi_cond_t *pi_cond_alloc(void)
+{
+	return malloc(sizeof(pi_cond_t));
+}
+
+void pi_cond_free(pi_cond_t *cond)
+{
+	free(cond);
+}
+
 int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 {
 	pthread_condattr_t attr;

--- a/pi_cond.c
+++ b/pi_cond.c
@@ -2,7 +2,10 @@
 // Copyright © 2018 VMware, Inc. All Rights Reserved.
 
 #include <stdio.h>
+#include <string.h>
+#include <limits.h>
 #include "rtpi_internal.h"
+#include "pi_futex.h"
 
 /*
  * This wrapper for early library validation only.
@@ -23,77 +26,80 @@ void pi_cond_free(pi_cond_t *cond)
 
 int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 {
-	pthread_condattr_t attr;
 	struct timespec ts = { 0, 0 };
 	int ret;
 
-	ret = pthread_condattr_init(&attr);
-	if (ret)
+	if (flags & ~(RTPI_COND_PSHARED)) {
+		ret = -EINVAL;
 		goto out;
-
-	/* All RTPI condvars are CLOCK_MONOTONIC */
-	ret = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-	if (ret)
-		goto out;
-
-	if (flags && RTPI_COND_PSHARED) {
-		ret = pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
-		if (ret)
-			goto out;
 	}
 
-	ret = pthread_cond_init(&cond->cond, &attr);
-	if (ret)
+	if (flags & RTPI_COND_PSHARED) {
+		cond->flags = RTPI_COND_PSHARED;
+	}
+
+	/* PSHARED has to match on both. */
+	if ((cond->flags & RTPI_COND_PSHARED) ^ (mutex->flags % RTPI_MUTEX_PSHARED)) {
+		ret = -EINVAL;
 		goto out;
+	}
 
 	cond->mutex = mutex;
 
-	/* Force association with the specified mutex */
-	ts.tv_nsec = 1;
-	ret = pi_mutex_lock(mutex);
-	if (ret)
-		goto out;
-	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->futex, &ts);
-	if (ret == ETIMEDOUT)
-		ret = 0;
-	else if (ret == 0)
-		ret = -EINVAL;
-
- out:
+	ret = 0;
+out:
 	return ret;
 }
 
 int pi_cond_destroy(pi_cond_t *cond)
 {
-	int ret;
-	ret = pthread_cond_destroy(&cond->cond);
-	return ret;
+	memset(cond, 0, sizeof(*cond));
+	return 0;
 }
 
 int pi_cond_wait(pi_cond_t *cond)
 {
 	int ret;
-	ret = pthread_cond_wait(&cond->cond, &cond->mutex->futex);
+
+	ret = pi_mutex_unlock(cond->mutex);
+	if (ret)
+		return ret;
+	ret = futex_wait_requeue_pi(cond, 0, NULL, cond->mutex,
+				    0xffffffff);
 	return ret;
 }
 
 int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 {
 	int ret;
-	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->futex, abstime);
+
+	ret = pi_mutex_unlock(cond->mutex);
+	if (ret)
+		return ret;
+	ret = futex_wait_requeue_pi(cond, 0, abstime,
+				    cond->mutex,
+				    0);
 	return ret;
 }
 
 int pi_cond_signal(pi_cond_t *cond)
 {
 	int ret;
-	ret = pthread_cond_signal(&cond->cond);
-	return ret;
+
+	ret = futex_cmp_requeue_PI(cond, 0, 0, cond->mutex,
+				   cond->cond);
+	if (ret < 0)
+		return ret;
+	return 0;
 }
 
 int pi_cond_broadcast(pi_cond_t *cond)
 {
 	int ret;
-	ret = pthread_cond_broadcast(&cond->cond);
-	return ret;
+
+	ret = futex_cmp_requeue_PI(cond, 0, INT_MAX, cond->mutex,
+				   cond->cond);
+	if (ret < 0)
+		return ret;
+	return 0;
 }

--- a/pi_cond.c
+++ b/pi_cond.c
@@ -53,7 +53,7 @@ int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 	ret = pi_mutex_lock(mutex);
 	if (ret)
 		goto out;
-	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->mutex, &ts);
+	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->futex, &ts);
 	if (ret == ETIMEDOUT)
 		ret = 0;
 	else if (ret == 0)
@@ -73,14 +73,14 @@ int pi_cond_destroy(pi_cond_t *cond)
 int pi_cond_wait(pi_cond_t *cond)
 {
 	int ret;
-	ret = pthread_cond_wait(&cond->cond, &cond->mutex->mutex);
+	ret = pthread_cond_wait(&cond->cond, &cond->mutex->futex);
 	return ret;
 }
 
 int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 {
 	int ret;
-	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->mutex, abstime);
+	ret = pthread_cond_timedwait(&cond->cond, &cond->mutex->futex, abstime);
 	return ret;
 }
 
@@ -97,4 +97,3 @@ int pi_cond_broadcast(pi_cond_t *cond)
 	ret = pthread_cond_broadcast(&cond->cond);
 	return ret;
 }
-

--- a/pi_futex.h
+++ b/pi_futex.h
@@ -1,0 +1,58 @@
+#ifndef PI_FUTEX_H
+#define PI_FUTEX_H
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/futex.h>
+
+static inline __u32 get_op(__u32 op, __u32 mod)
+{
+	if (!(mod & RTPI_MUTEX_PSHARED))
+		op |= FUTEX_PRIVATE_FLAG;
+	return op;
+}
+
+static inline int sys_futex(__u32 *addr, int op, __u32 val,
+			    const struct timespec *restrict utime,
+			    __u32 *uaddr2, __u32 val3)
+{
+	return syscall(SYS_futex, addr, op, val, utime, uaddr2, val3);
+}
+
+static inline int futex_lock_pi(pi_mutex_t *mutex)
+{
+	return sys_futex(&mutex->futex,
+			 get_op(FUTEX_LOCK_PI, mutex->flags),
+			 0, NULL, 0, 0);
+}
+
+static inline int futex_unlock_pi(pi_mutex_t *mutex)
+{
+	return sys_futex(&mutex->futex,
+			 get_op(FUTEX_UNLOCK_PI, mutex->flags),
+			 0, NULL, 0, 0);
+}
+
+static inline int futex_wait_requeue_pi(pi_cond_t *cond, __u32 val,
+					const struct timespec *restrict utime,
+					pi_mutex_t *mutex, __u32 val3)
+{
+	return sys_futex(&cond->cond,
+			 get_op(FUTEX_WAIT_REQUEUE_PI, cond->flags),
+			 val, utime,
+			 &mutex->futex, val3);
+}
+
+static inline int futex_cmp_requeue_PI(pi_cond_t *cond, __u32 val,
+				       __u32 val2,
+				       pi_mutex_t *mutex, __u32 val3)
+{
+	return sys_futex(&cond->cond,
+			 get_op(FUTEX_CMP_REQUEUE_PI, cond->flags),
+			 1,
+			 (void *)(long)val2, &mutex->futex,
+			 val3);
+}
+
+#endif

--- a/pi_futex.h
+++ b/pi_futex.h
@@ -52,7 +52,7 @@ static inline int futex_cmp_requeue_PI(pi_cond_t *cond, __u32 val,
 			 get_op(FUTEX_CMP_REQUEUE_PI, cond->flags),
 			 1,
 			 (void *)(long)val2, &mutex->futex,
-			 val3);
+			 val);
 }
 
 #endif

--- a/pi_futex.h
+++ b/pi_futex.h
@@ -46,7 +46,7 @@ static inline int futex_wait_requeue_pi(pi_cond_t *cond, __u32 val,
 
 static inline int futex_cmp_requeue_PI(pi_cond_t *cond, __u32 val,
 				       __u32 val2,
-				       pi_mutex_t *mutex, __u32 val3)
+				       pi_mutex_t *mutex)
 {
 	return sys_futex(&cond->cond,
 			 get_op(FUTEX_CMP_REQUEUE_PI, cond->flags),

--- a/pi_mutex.c
+++ b/pi_mutex.c
@@ -1,7 +1,17 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 // Copyright © 2018 VMware, Inc. All Rights Reserved.
 
-#include "rtpi.h"
+#include "rtpi_internal.h"
+
+pi_mutex_t *pi_mutex_alloc(void)
+{
+	return malloc(sizeof(pi_mutex_t));
+}
+
+void pi_mutex_free(pi_mutex_t *mutex)
+{
+	free(mutex);
+}
 
 int pi_mutex_init(pi_mutex_t *mutex, uint32_t flags)
 {

--- a/pi_mutex.c
+++ b/pi_mutex.c
@@ -29,7 +29,6 @@ void pi_mutex_free(pi_mutex_t *mutex)
 
 int pi_mutex_init(pi_mutex_t *mutex, uint32_t flags)
 {
-	pthread_mutexattr_t attr;
 	int ret;
 
 	/* All RTPI mutexes are PRIO_INHERIT */

--- a/rtpi.h
+++ b/rtpi.h
@@ -40,7 +40,7 @@ int pi_mutex_unlock(pi_mutex_t *mutex);
  * PI Cond Interface
  */
 
-#define RTPI_COND_PSHARED     0x1
+#define RTPI_COND_PSHARED     RTPI_MUTEX_PSHARED
 
 pi_cond_t *pi_cond_alloc(void);
 

--- a/rtpi.h
+++ b/rtpi.h
@@ -7,17 +7,11 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <pthread.h>
+#include <stdlib.h>
 #include <time.h>
 
-/* TODO: Make these opaque types */
-typedef struct pi_mutex {
-	pthread_mutex_t mutex;
-} pi_mutex_t;
-
-typedef struct pi_cond {
-	pthread_cond_t cond;
-	pi_mutex_t *mutex;
-} pi_cond_t;
+typedef struct pi_mutex pi_mutex_t;
+typedef struct pi_cond pi_cond_t;
 
 /*
  * PI Mutex Interface
@@ -26,6 +20,10 @@ typedef struct pi_cond {
 #define RTPI_MUTEX_PSHARED    0x1
 //#define RTPI_MUTEX_ROBUST     0x2
 //#define RTPI_MUTEX_ERRORCHECK 0x4
+
+pi_mutex_t *pi_mutex_alloc(void);
+
+void pi_mutex_free(pi_mutex_t *mutex);
 
 int pi_mutex_init(pi_mutex_t *mutex, uint32_t flags);
 
@@ -43,6 +41,10 @@ int pi_mutex_unlock(pi_mutex_t *mutex);
  */
 
 #define RTPI_COND_PSHARED     0x1
+
+pi_cond_t *pi_cond_alloc(void);
+
+void pi_cond_free(pi_cond_t *cond);
 
 int pi_cond_init(pi_cond_t *cond, pi_mutex_t *mutex, uint32_t flags);
 

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -4,15 +4,18 @@
 #ifndef _RTPI_INTERNAL_H
 #define _RTPI_INTERNAL_H
 
+#include <linux/futex.h>
+
 #include "rtpi.h"
 
 typedef struct pi_mutex {
-	unsigned int futex;
-	unsigned int flags;
+	__u32 futex;
+	__u32 flags;
 } pi_mutex_t;
 
 typedef struct pi_cond {
-	pthread_cond_t cond;
+	__u32 cond;
+	__u32 flags;
 	pi_mutex_t *mutex;
 } pi_cond_t;
 

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -7,7 +7,8 @@
 #include "rtpi.h"
 
 typedef struct pi_mutex {
-	pthread_mutex_t mutex;
+	unsigned int futex;
+	unsigned int flags;
 } pi_mutex_t;
 
 typedef struct pi_cond {

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+/* Copyright © 2018 VMware, Inc. All Rights Reserved. */
+
+#ifndef _RTPI_INTERNAL_H
+#define _RTPI_INTERNAL_H
+
+#include "rtpi.h"
+
+typedef struct pi_mutex {
+	pthread_mutex_t mutex;
+} pi_mutex_t;
+
+typedef struct pi_cond {
+	pthread_cond_t cond;
+	pi_mutex_t *mutex;
+} pi_cond_t;
+
+#endif // _RTPI_INTERNAL_H

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -9,14 +9,19 @@
 #include "rtpi.h"
 
 typedef struct pi_mutex {
-	__u32 futex;
-	__u32 flags;
+	__u32	futex;
+	__u32	flags;
 } pi_mutex_t;
 
 typedef struct pi_cond {
-	__u32 cond;
-	__u32 flags;
-	pi_mutex_t *mutex;
+	__u32		cond;
+	__u32		flags;
+
+	pi_mutex_t	priv_mut;
+	__u32		wake_id;
+	__u32		pending_wake;
+	__u32		pending_wait;
+	pi_mutex_t	*mutex;
 } pi_cond_t;
 
 #endif // _RTPI_INTERNAL_H

--- a/test.c
+++ b/test.c
@@ -8,24 +8,34 @@
 
 int main(int argc, char *argv)
 {
-	pi_mutex_t mutex;
-	pi_cond_t cond;
+	pi_mutex_t *mutex;
+	pi_cond_t *cond;
 	int ret;
 
-	ret = pi_mutex_init(&mutex, 0x0);
+	mutex = pi_mutex_alloc();
+	if (!mutex) {
+		printf("ERROR: failed to allocated a mutex.\n");
+		goto out;
+	}
+	cond = pi_cond_alloc();
+	if (!cond) {
+		printf("ERROR: failed to allocated a cond.\n");
+		goto out;
+	}
+	ret = pi_mutex_init(mutex, 0x0);
 	if (ret) {
 		printf("ERROR: pi_mutex_init returned %d\n", ret);
 		goto out;
 	}
 
-	ret = pi_cond_init(&cond, &mutex, 0x0);
+	ret = pi_cond_init(cond, mutex, 0x0);
 	if (ret) {
 		printf("ERROR: pi_cond_init returned %d\n", ret);
 		goto out;
 	}
 
-	printf("mutex @ %p\n", &mutex);
-	printf("cond @ %p\n", &cond);
+	printf("mutex @ %p\n", mutex);
+	printf("cond @ %p\n", cond);
 
  out:
 	return ret;

--- a/tst-cond.c
+++ b/tst-cond.c
@@ -1,0 +1,288 @@
+/* Copyright (C) 2002, 2010, 2013 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Darren Hart <dvhltc@us.ibm.com>
+   Based on pthread_cond_hang.c by Dinakar Guniguntala <dino@in.ibm.com>
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#define _GNU_SOURCE
+#include <error.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define LOW_PRIO  1
+#define MED_PRIO  2
+#define HIGH_PRIO 3
+#define MAIN_PRIO 4
+
+static pthread_cond_t race_var;
+static pthread_mutex_t race_mut;
+
+static pthread_cond_t sig1, sig2, sig3;
+static pthread_mutex_t m1, m2, m3;
+
+static volatile unsigned int done = 0;
+
+static void *
+low_tf (void *p)
+{
+  int err;
+
+  /* Wait for do_test to start all the threads.  */
+  err = pthread_mutex_lock (&m1);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: failed to lock m1");
+  err = pthread_cond_wait (&sig1, &m1);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: cond_wait failed on sig1");
+
+  err = pthread_mutex_lock (&race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: failed to lock race_mut");
+
+  puts ("low_tf: locked");
+
+  /* Signal the high_tf that we have the race_mut, it will preempt us until it
+   * blocks on race_mut.  */
+  err = pthread_cond_signal (&sig2);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: failed to signal sig2");
+
+  /* pthread_cond_wait() holds the cond_lock when it unlocks race_mut.  high_tf
+     will preempt us before we can release the cond_lock.  It will signal med_tf
+     which will continue to block us after high_tf tries to block on race_var if
+     it isn't PTHREAD_PRIO_INHERIT, and the cond_lock will never be released.  */
+  err = pthread_cond_wait (&race_var, &race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: cond_wait failed on race_var");
+
+  puts ("low_tf: done waiting");
+
+  err = pthread_mutex_unlock (&race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "low_tf: failed to unlock race_mut");
+
+  return NULL;
+}
+
+static void *
+high_tf (void *p)
+{
+  int err;
+
+  err = pthread_mutex_lock (&m2);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: failed to lock m2");
+
+  /* Wait for low_tf to take race_mut and signal us.  We will preempt low_tf
+   * until we block on race_mut below.  */
+  err = pthread_cond_wait (&sig2, &m2);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: cond_wait failed on sig2");
+
+  /* Wait for low_tf to release the lock as it waits on race_var.  */
+  err = pthread_mutex_lock (&race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: failed to lock race_mut");
+
+  puts ("high_tf: locked");
+
+  /* Signal the med_tf to start spinning.  */
+  err = pthread_cond_signal (&sig3);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: failed to signal sig3");
+
+  /* If the race_var isn't PTHREAD_PRIO_INHERIT, we will block on the
+     race_var cond_lock waiting for the low_tf to release it in it's
+     pthread_cond_wait(&race_var, &race_mut) call.  */
+  err = pthread_cond_wait (&race_var, &race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: cond_wait failed on race_var");
+
+  puts ("high_tf: done waiting");
+
+  err = pthread_mutex_unlock (&race_mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "high_tf: failed to unlock race_mut");
+
+  done = 1;
+  return NULL;
+}
+
+static void *
+med_tf (void *p)
+{
+  int err;
+
+  err = pthread_mutex_lock (&m3);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "med_tf: failed to lock m3");
+
+  /* Wait for high_tf to signal us.  */
+  err = pthread_cond_wait (&sig3, &m3);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "med_tf: cond_wait failed on sig3");
+
+  puts ("med_tf: spinning");
+
+  while (!done)
+          /* Busy wait to block low threads.  */;
+
+  puts ("med_tf: done spinning");
+
+  return NULL;
+}
+
+static int
+do_test (void)
+{
+  pthread_t low_thread;
+  pthread_t med_thread;
+  pthread_t high_thread;
+  struct sched_param param;
+  pthread_attr_t attr;
+  pthread_mutexattr_t m_attr;
+  pthread_condattr_t c_attr;
+  cpu_set_t cset;
+
+  int err;
+
+
+  /* Initialize mutexes and condvars.  */
+
+  err = pthread_attr_init (&attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init pthread_attr");
+  err = pthread_attr_setinheritsched (&attr, PTHREAD_EXPLICIT_SCHED);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set attr inheritsched");
+  err = pthread_attr_setschedpolicy (&attr, SCHED_FIFO);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set attr schedpolicy");
+
+  err = pthread_condattr_init (&c_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init condattr");
+
+  err = pthread_cond_init (&sig1, &c_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig1");
+  err = pthread_cond_init (&sig2, &c_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig2");
+  err = pthread_cond_init (&sig3, &c_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig3");
+  err = pthread_cond_init (&race_var, &c_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond race_var");
+
+  err = pthread_mutexattr_init (&m_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init mutexattr");
+  err = pthread_mutexattr_setprotocol (&m_attr, PTHREAD_PRIO_INHERIT);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set mutexattr protocol");
+  err = pthread_mutex_init (&m1, &m_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init mutex m1");
+  err = pthread_mutex_init (&m2, &m_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init mutex m2");
+  err = pthread_mutex_init (&m3, &m_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init mutex m3");
+  err = pthread_mutex_init (&race_mut, &m_attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init mutex race_mut");
+
+  /* Setup scheduling parameters and create threads.  */
+  param.sched_priority = MAIN_PRIO;
+  err = sched_setscheduler (0, SCHED_FIFO, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set scheduler policy");
+
+  CPU_ZERO (&cset);
+  CPU_SET (0, &cset);
+  err = sched_setaffinity (0, sizeof (cpu_set_t), &cset);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set CPU affinity");
+
+  param.sched_priority = LOW_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for low_tf");
+  err = pthread_create (&low_thread, &attr, low_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create low_tf");
+
+  param.sched_priority = MED_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for med_tf");
+  pthread_create (&med_thread, &attr, med_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create med_tf");
+
+  param.sched_priority = HIGH_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for high_tf");
+  err = pthread_create (&high_thread, &attr, high_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create high_tf");
+
+  /* Wait for the threads to start and block on their respective condvars.  */
+  usleep (1000);
+  err = pthread_cond_signal (&sig1);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to signal condition");
+
+  /* Wake low_tf and high_tf, allowing them to complete.  If race_var is not
+     PTHREAD_PRIO_INHERIT, low_tf will not have released the race_var cond_lock
+     and neither thread will have waited on race_var.  */
+  usleep (1000);
+  err = pthread_cond_broadcast (&race_var);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to broadcast condition");
+
+  /* Wait for threads to complete.  */
+  err = pthread_join (low_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of low_tf failed");
+  err = pthread_join (med_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of med_tf failed");
+  err = pthread_join (high_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of high_tf failed");
+
+  puts ("done");
+
+  return 0;
+}
+
+int main(void)
+{
+	do_test();
+	return 0;
+}

--- a/tst-cond.c
+++ b/tst-cond.c
@@ -20,25 +20,25 @@
 #define _GNU_SOURCE
 #include <error.h>
 #include <errno.h>
-#include <pthread.h>
 #include <sched.h>
 #include <stdio.h>
-#include <stdlib.h>
+#include <pthread.h>
 #include <string.h>
 #include <time.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include "rtpi.h"
 
 #define LOW_PRIO  1
 #define MED_PRIO  2
 #define HIGH_PRIO 3
 #define MAIN_PRIO 4
 
-static pthread_cond_t race_var;
-static pthread_mutex_t race_mut;
+static pi_cond_t *race_var;
+static pi_mutex_t *race_mut;
 
-static pthread_cond_t sig1, sig2, sig3;
-static pthread_mutex_t m1, m2, m3;
+static pi_cond_t *sig1, *sig2, *sig3;
+static pi_mutex_t *m1, *m2, *m3;
 
 static volatile unsigned int done = 0;
 
@@ -48,14 +48,14 @@ low_tf (void *p)
   int err;
 
   /* Wait for do_test to start all the threads.  */
-  err = pthread_mutex_lock (&m1);
+  err = pi_mutex_lock (m1);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: failed to lock m1");
-  err = pthread_cond_wait (&sig1, &m1);
+  err = pi_cond_wait (sig1);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: cond_wait failed on sig1");
 
-  err = pthread_mutex_lock (&race_mut);
+  err = pi_mutex_lock (race_mut);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: failed to lock race_mut");
 
@@ -63,21 +63,21 @@ low_tf (void *p)
 
   /* Signal the high_tf that we have the race_mut, it will preempt us until it
    * blocks on race_mut.  */
-  err = pthread_cond_signal (&sig2);
+  err = pi_cond_signal (sig2);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: failed to signal sig2");
 
-  /* pthread_cond_wait() holds the cond_lock when it unlocks race_mut.  high_tf
+  /* pi_cond_wait() holds the cond_lock when it unlocks race_mut.  high_tf
      will preempt us before we can release the cond_lock.  It will signal med_tf
      which will continue to block us after high_tf tries to block on race_var if
      it isn't PTHREAD_PRIO_INHERIT, and the cond_lock will never be released.  */
-  err = pthread_cond_wait (&race_var, &race_mut);
+  err = pi_cond_wait (race_var);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: cond_wait failed on race_var");
 
   puts ("low_tf: done waiting");
 
-  err = pthread_mutex_unlock (&race_mut);
+  err = pi_mutex_unlock (race_mut);
   if (err != 0)
     error (EXIT_FAILURE, err, "low_tf: failed to unlock race_mut");
 
@@ -89,38 +89,38 @@ high_tf (void *p)
 {
   int err;
 
-  err = pthread_mutex_lock (&m2);
+  err = pi_mutex_lock (m2);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: failed to lock m2");
 
   /* Wait for low_tf to take race_mut and signal us.  We will preempt low_tf
    * until we block on race_mut below.  */
-  err = pthread_cond_wait (&sig2, &m2);
+  err = pi_cond_wait (sig2);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: cond_wait failed on sig2");
 
   /* Wait for low_tf to release the lock as it waits on race_var.  */
-  err = pthread_mutex_lock (&race_mut);
+  err = pi_mutex_lock (race_mut);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: failed to lock race_mut");
 
   puts ("high_tf: locked");
 
   /* Signal the med_tf to start spinning.  */
-  err = pthread_cond_signal (&sig3);
+  err = pi_cond_signal (sig3);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: failed to signal sig3");
 
   /* If the race_var isn't PTHREAD_PRIO_INHERIT, we will block on the
      race_var cond_lock waiting for the low_tf to release it in it's
-     pthread_cond_wait(&race_var, &race_mut) call.  */
-  err = pthread_cond_wait (&race_var, &race_mut);
+     pi_cond_wait(&race_var, &race_mut) call.  */
+  err = pi_cond_wait (race_var);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: cond_wait failed on race_var");
 
   puts ("high_tf: done waiting");
 
-  err = pthread_mutex_unlock (&race_mut);
+  err = pi_mutex_unlock (race_mut);
   if (err != 0)
     error (EXIT_FAILURE, err, "high_tf: failed to unlock race_mut");
 
@@ -133,12 +133,12 @@ med_tf (void *p)
 {
   int err;
 
-  err = pthread_mutex_lock (&m3);
+  err = pi_mutex_lock (m3);
   if (err != 0)
     error (EXIT_FAILURE, err, "med_tf: failed to lock m3");
 
   /* Wait for high_tf to signal us.  */
-  err = pthread_cond_wait (&sig3, &m3);
+  err = pi_cond_wait (sig3);
   if (err != 0)
     error (EXIT_FAILURE, err, "med_tf: cond_wait failed on sig3");
 
@@ -160,10 +160,7 @@ do_test (void)
   pthread_t high_thread;
   struct sched_param param;
   pthread_attr_t attr;
-  pthread_mutexattr_t m_attr;
-  pthread_condattr_t c_attr;
   cpu_set_t cset;
-
   int err;
 
 
@@ -179,41 +176,44 @@ do_test (void)
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to set attr schedpolicy");
 
-  err = pthread_condattr_init (&c_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init condattr");
+  race_mut = pi_mutex_alloc();
+  m1 = pi_mutex_alloc();
+  m2 = pi_mutex_alloc();
+  m3 = pi_mutex_alloc();
 
-  err = pthread_cond_init (&sig1, &c_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init cond sig1");
-  err = pthread_cond_init (&sig2, &c_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init cond sig2");
-  err = pthread_cond_init (&sig3, &c_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init cond sig3");
-  err = pthread_cond_init (&race_var, &c_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init cond race_var");
+  race_var = pi_cond_alloc();
+  sig1 = pi_cond_alloc();
+  sig2 = pi_cond_alloc();
+  sig3 = pi_cond_alloc();
 
-  err = pthread_mutexattr_init (&m_attr);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to init mutexattr");
-  err = pthread_mutexattr_setprotocol (&m_attr, PTHREAD_PRIO_INHERIT);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to set mutexattr protocol");
-  err = pthread_mutex_init (&m1, &m_attr);
+  err = pi_mutex_init (m1, 0);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to init mutex m1");
-  err = pthread_mutex_init (&m2, &m_attr);
+  err = pi_mutex_init (m2, 0);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to init mutex m2");
-  err = pthread_mutex_init (&m3, &m_attr);
+  err = pi_mutex_init (m3, 0);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to init mutex m3");
-  err = pthread_mutex_init (&race_mut, &m_attr);
+  err = pi_mutex_init (race_mut, 0);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to init mutex race_mut");
+
+  err = pi_cond_init (sig1, m1, 0);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig1");
+
+  err = pi_cond_init (sig2, m2, 0);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig2");
+
+  err = pi_cond_init (sig3, m3, 0);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond sig3");
+
+  err = pi_cond_init (race_var, race_mut, 0);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init cond race_var");
 
   /* Setup scheduling parameters and create threads.  */
   param.sched_priority = MAIN_PRIO;
@@ -253,7 +253,7 @@ do_test (void)
 
   /* Wait for the threads to start and block on their respective condvars.  */
   usleep (1000);
-  err = pthread_cond_signal (&sig1);
+  err = pi_cond_signal (sig1);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to signal condition");
 
@@ -261,7 +261,7 @@ do_test (void)
      PTHREAD_PRIO_INHERIT, low_tf will not have released the race_var cond_lock
      and neither thread will have waited on race_var.  */
   usleep (1000);
-  err = pthread_cond_broadcast (&race_var);
+  err = pi_cond_broadcast (race_var);
   if (err != 0)
     error (EXIT_FAILURE, err, "parent: failed to broadcast condition");
 

--- a/tst-cond1.c
+++ b/tst-cond1.c
@@ -1,0 +1,111 @@
+/* Copyright (C) 2002, 2010, 2013 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Darren Hart <dvhltc@us.ibm.com>
+   Based on pthread_cond_hang.c by Dinakar Guniguntala <dino@in.ibm.com>
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#define _GNU_SOURCE
+#include <error.h>
+#include <errno.h>
+#include <sched.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "rtpi.h"
+
+static pi_cond_t *sig1;
+static pi_mutex_t *m1;
+
+static volatile unsigned int done = 0;
+
+static void *low_tf (void *p)
+{
+	int num = (int) p;
+	int err;
+
+	/* Wait for do_test to start all the threads.  */
+	err = pi_mutex_lock (m1);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "T%d: failed to lock m1\n", num);
+
+	err = pi_cond_wait (sig1);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "T%d: cond_wait failed on sig1\n", num);
+
+	err = pi_mutex_unlock (m1);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "T%d: failed to unlock race_mut\n", num);
+	printf("Leave %d\n", num);
+	return NULL;
+}
+
+static int do_test (void)
+{
+	pthread_t tthread[20];
+	pthread_attr_t attr;
+	int i;
+	int err;
+
+	/* Initialize mutexes and condvars.  */
+	err = pthread_attr_init (&attr);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "parent: failed to init pthread_attr");
+
+	m1 = pi_mutex_alloc();
+	sig1 = pi_cond_alloc();
+
+	err = pi_mutex_init (m1, 0);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "parent: failed to init mutex m1");
+
+	err = pi_cond_init (sig1, m1, 0);
+	if (err != 0)
+		error (EXIT_FAILURE, err, "parent: failed to init cond sig1");
+
+	for (i = 0; i < 20; i++) {
+		err = pthread_create (&tthread[i], &attr, low_tf, (void *)(long)i);
+		if (err != 0)
+			error (EXIT_FAILURE, err, "parent: failed to create low_tf");
+	}
+
+	/* Wait for the threads to start and block on their respective condvars.  */
+	for (i = 0; i < 20; i++) {
+		sleep (1);
+		printf("Sig %d\n", i);
+		err = pi_cond_signal (sig1);
+		if (err != 0)
+			error (EXIT_FAILURE, err, "parent: failed to signal condition");
+	}
+
+	for (i = 0; i < 20; i++) {
+		err = pthread_join (tthread[i], NULL);
+		if (err != 0)
+			error (EXIT_FAILURE, err, "join of low_tf failed");
+	}
+
+	puts ("done");
+
+	return 0;
+}
+
+int main(void)
+{
+	do_test();
+	return 0;
+}

--- a/tst-cond1.c
+++ b/tst-cond1.c
@@ -85,13 +85,15 @@ static int do_test (void)
 	}
 
 	/* Wait for the threads to start and block on their respective condvars.  */
-	for (i = 0; i < 20; i++) {
+	for (i = 0; i < 2; i++) {
 		sleep (1);
 		printf("Sig %d\n", i);
 		err = pi_cond_signal (sig1);
 		if (err != 0)
 			error (EXIT_FAILURE, err, "parent: failed to signal condition");
 	}
+	printf("BROAD\n");
+	err = pi_cond_broadcast (sig1);
 
 	for (i = 0; i < 20; i++) {
 		err = pthread_join (tthread[i], NULL);


### PR DESCRIPTION
Most of this has been hacked during Summit on a Summit 2018 together with Julia Cartwright. I managed to fix the testcase from bugzilla over the weekend and here it is, still incomplete.

From the API:
- pi_cond_init() has a flags argument which has currently option: SHARED | PRIVATE. I don't think this makes sense It. It has to match the value of the futex.
- This is currently a two-stage operation: First init a mutex, second pass the mutex while performing the init of the cond-var. Couldn't we do instead:
   int pi_cond_alloc(pi_cond_t *cond, pi_mutex_t *mutex)
and allocate both in one go? We could make the second mutex part pi_cond_t struct.

The testcase from glibc seems to pass now. The TC is timing sensitive. If the udelay() is not large enough it is possible that the signal/wake occurs before the thread had time wait/sleep.

Missing:
- The counters are not overflow safe
- the timeout part is missing
- OWNERDEAD is not tested
- signal + broadcast code could be merged.
- For compare-exchange I used the gcc atomic op. Julia had something different (stdatomic). I'm not sure what is better. Julia's has probably better defined sematics than the gcc's "just work" ones. I don't know what gcc/compiler requirements we want. Maybe we could use configure to select Julia by default if it works and fallback to the other one.
- there should be a linker script which only exposes the functions / variables defined as API.

I'm adding this here because Julia wanted to take a look and maybe do more work and I have no time when I get some time again…

