### PR TITLE
pi_cond: Add sequence counters

### DIFF
--- a/pi_cond.c
+++ b/pi_cond.c
@@ -33,7 +33,7 @@ int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 		ret = -EINVAL;
 		goto out;
 	}
-
+	memset(cond, 0, sizeof(*cond));
 	if (flags & RTPI_COND_PSHARED) {
 		cond->flags = RTPI_COND_PSHARED;
 	}
@@ -43,7 +43,7 @@ int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
 		ret = -EINVAL;
 		goto out;
 	}
-
+	pi_mutex_init(&cond->priv_mut, cond->flags & RTPI_COND_PSHARED);
 	cond->mutex = mutex;
 
 	ret = 0;
@@ -60,11 +60,62 @@ int pi_cond_destroy(pi_cond_t *cond)
 int pi_cond_wait(pi_cond_t *cond)
 {
 	int ret;
+	__u32 wait_id;
+	__u32 futex_id;
 
-	ret = pi_mutex_unlock(cond->mutex);
+	ret = pi_mutex_lock(&cond->priv_mut);
 	if (ret)
 		return ret;
-	ret = futex_wait_requeue_pi(cond, 0, NULL, cond->mutex);
+
+	ret = pi_mutex_unlock(cond->mutex);
+	if (ret) {
+		pi_mutex_unlock(&cond->priv_mut);
+		return ret;
+	}
+	cond->pending_wait++;
+	cond->cond++;
+	wait_id = cond->cond;
+	do {
+
+		futex_id = cond->cond;
+		pi_mutex_unlock(&cond->priv_mut);
+
+		ret = futex_wait_requeue_pi(cond, futex_id, NULL, cond->mutex);
+		if (ret < 0) {
+			if (errno == EAGAIN) {
+				/* futex VAL changed between unlock & wait */
+				pi_mutex_lock(&cond->priv_mut);
+				if (cond->wake_id >= wait_id && cond->pending_wake) {
+					/* There is one wakeup pending for us */
+					cond->pending_wake--;
+					cond->pending_wait--;
+					pi_mutex_unlock(&cond->priv_mut);
+					pi_mutex_lock(cond->mutex);
+					ret = 0;
+					break;
+				}
+				/* Reload VAL and try again */
+				continue;
+			} else {
+				/* Error, abort */
+				pi_mutex_lock(&cond->priv_mut);
+				cond->pending_wait--;
+				pi_mutex_unlock(&cond->priv_mut);
+				ret = -errno;
+				break;
+			}
+		}
+		/* All good. Proper wakeup + we own the lock */
+		if (cond->pending_wake) {
+			cond->pending_wait--;
+			cond->pending_wake--;
+			pi_mutex_unlock(&cond->priv_mut);
+			pi_mutex_lock(cond->mutex);
+			ret = 0;
+			break;
+		}
+		/* No wakeup for us, try again… */
+	} while (1);
 	return ret;
 }
 
@@ -82,21 +133,79 @@ int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 int pi_cond_signal(pi_cond_t *cond)
 {
 	int ret;
+	__u32 id;
 
-	ret = futex_cmp_requeue_pi(cond, 0, 0, cond->mutex);
+	pi_mutex_lock(&cond->priv_mut);
 
-	if (ret < 0)
-		return ret;
+	if (!cond->pending_wait) {
+		/* No waiters pending */
+		pi_mutex_unlock(&cond->priv_mut);
+		return 0;
+	}
+	cond->cond++;
+	id = cond->cond;
+	cond->wake_id = id;
+	cond->pending_wake++;
+	pi_mutex_unlock(&cond->priv_mut);
+
+	do {
+		ret = futex_cmp_requeue_pi(cond, id, 0, cond->mutex);
+		if (ret > 0) {
+			/* Wakeup performed */
+			break;
+		} else if (ret == 0) {
+			/* nothing woke up */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->pending_wake--;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else if (errno == EAGAIN) {
+			/* id changed */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->cond++;
+			id = cond->cond;
+			cond->wake_id = id;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else {
+			return -errno;
+		}
+	} while (1);
 	return 0;
 }
 
 int pi_cond_broadcast(pi_cond_t *cond)
 {
 	int ret;
+	__u32 id;
 
-	ret = futex_cmp_requeue_pi(cond, 0, INT_MAX, cond->mutex);
+	pi_mutex_lock(&cond->priv_mut);
 
-	if (ret < 0)
-		return ret;
+	if (!cond->pending_wait) {
+		/* No waiters pending */
+		pi_mutex_unlock(&cond->priv_mut);
+		return 0;
+	}
+	cond->cond++;
+	id = cond->cond;
+	cond->wake_id = id;
+	cond->pending_wake = cond->pending_wait;
+	pi_mutex_unlock(&cond->priv_mut);
+
+	do {
+		ret = futex_cmp_requeue_pi(cond, id, INT_MAX, cond->mutex);
+		if (ret >= 0) {
+			/* Wakeup performed */
+			break;
+		} else if (errno == EAGAIN) {
+			/* id changed */
+			pi_mutex_lock(&cond->priv_mut);
+			cond->cond++;
+			id = cond->cond;
+			cond->wake_id = id;
+			cond->pending_wake = cond->pending_wait;
+			pi_mutex_unlock(&cond->priv_mut);
+		} else {
+			return ret;
+		}
+	} while (1);
 	return 0;
 }

--- a/pi_mutex.c
+++ b/pi_mutex.c
@@ -57,8 +57,11 @@ int pi_mutex_lock(pi_mutex_t *mutex)
 {
 	if (pi_mutex_trylock(mutex))
 		return 0;
+	/* XXX EWNERDEAD */
 	return futex_lock_pi(mutex);
 }
+
+#define FUTEX_TID_MASK          0x3fffffff
 
 int pi_mutex_trylock(pi_mutex_t *mutex)
 {
@@ -66,6 +69,9 @@ int pi_mutex_trylock(pi_mutex_t *mutex)
 	bool ret;
 
 	pid = gettid();
+	if (pid == (mutex->futex & FUTEX_TID_MASK))
+		return -EDEADLOCK;
+
 	ret = __sync_bool_compare_and_swap(&mutex->futex,
 					   0, pid);
 	if (ret == true)
@@ -79,6 +85,10 @@ int pi_mutex_unlock(pi_mutex_t *mutex)
 	bool ret;
 
 	pid = gettid();
+#if 0
+	XXX
+	if (pid != (mutex->futex & FUTEX_TID_MASK))
+#endif
 	ret = __sync_bool_compare_and_swap(&mutex->futex,
 					   pid, 0);
 	if (ret == true)

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -9,14 +9,19 @@
 #include "rtpi.h"
 
 typedef struct pi_mutex {
-	__u32 futex;
-	__u32 flags;
+	__u32	futex;
+	__u32	flags;
 } pi_mutex_t;
 
 typedef struct pi_cond {
-	__u32 cond;
-	__u32 flags;
-	pi_mutex_t *mutex;
+	__u32		cond;
+	__u32		flags;
+
+	pi_mutex_t	priv_mut;
+	__u32		wake_id;
+	__u32		pending_wake;
+	__u32		pending_wait;
+	pi_mutex_t	*mutex;
 } pi_cond_t;
 
 #endif // _RTPI_INTERNAL_H


### PR DESCRIPTION
NOTE: this version was adapted from Sebastian's PR-4 with one significant change. His version used cond->priv_mut as the target for the futex_cmp_requeue_pi() calls - this would result in the pi_cond_wait() call returning with the cond->priv_mut held, and not the associated mutex (cond->mutex) held, which is the correct behavior. This version uses cond->mutex as the target and returns with that lock held.

It basically worked. However, if a thread is calling pi_cond_wait() and
is interrupted after dropping the mutex then it could happen that the
syscall is entered _after_ the wakeup occured which it missed. So here
we have counters which are modified untder the private lock:

The futex (cond) id is incremented during each wait and wakeup.

If the waiter raced against a waker then the syscall will return EAGAIN
and the waiter has to retry. If wake_id >= the futex value then it was
woken but missed it. In that case it is safe to return as successfully
woken. Otherwise the operation has to be retried.

Notes / TODO:
 - The id magic is not overlfow safe.
 - Timeouts are not implemented

Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
[dvhart: use cond->mutex as target for futex_wait_requeue_pi() calls]
Signed-off-by: Darren Hart (VMware) <dvhart@infradead.org>