### PR TITLE
Fix reserved identifier violation in header guards

### DIFF
--- a/rtpi.h
+++ b/rtpi.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /* Copyright © 2018 VMware, Inc. All Rights Reserved. */
 
-#ifndef _RTPI_H
-#define _RTPI_H
+#ifndef RPTI_H
+#define RPTI_H
 
 #include <errno.h>
 #include <inttypes.h>
@@ -58,4 +58,4 @@ int pi_cond_signal(pi_cond_t *cond);
 
 int pi_cond_broadcast(pi_cond_t *cond);
 
-#endif // _RTPI_H
+#endif // RPTI_H

--- a/rtpi_internal.h
+++ b/rtpi_internal.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: LGPL-2.1-only */
 /* Copyright © 2018 VMware, Inc. All Rights Reserved. */
 
-#ifndef _RTPI_INTERNAL_H
-#define _RTPI_INTERNAL_H
+#ifndef RPTI_H_INTERNAL_H
+#define RPTI_H_INTERNAL_H
 
 #include <linux/futex.h>
 
@@ -24,4 +24,4 @@ typedef struct pi_cond {
 	pi_mutex_t	*mutex;
 } pi_cond_t;
 
-#endif // _RTPI_INTERNAL_H
+#endif // RPTI_H_INTERNAL_H


### PR DESCRIPTION
The header guards for rtpi.h and rtpi_internal.h used a leading _
followed by an uppercase letter, which is a reserved identifier in
the 1999 C standard:

7.1.3 Reserved identifiers
  Each header declares or defines all identifiers listed in its
  associated subclause, and optionally declares or defines identifiers
  listed in its associated future library directions subclause and
  identifiers which are always reserved either for any use or for use as
  file scope identifiers.

  - All identifiers that begin with an underscore and either an
    uppercase letter or another underscore are always reserved for any
    use.
  ...

Fixes #9

Signed-off-by: Darren Hart (VMware) <dvhart@infradead.org>