### PR TITLE
Import glibc tests

### DIFF
--- a/tests/glibc-tests/test-driver.c
+++ b/tests/glibc-tests/test-driver.c
@@ -1,0 +1,341 @@
+/* Main function for test programs.
+   Copyright (C) 2016-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+/* This file should be included from test cases.  It will define a
+   main function which provides the test wrapper.
+
+   It assumes that the test case defines a function
+
+     int do_test (void);
+
+   and arranges for that function being called under the test wrapper.
+   The do_test function should return 0 to indicate a passing test, 1
+   to indicate a failing test, or 77 to indicate an unsupported test.
+   Other result values could be used to indicate a failing test, but
+   the result of the expression is passed to exit and exit only
+   returns the lower 8 bits of its input.  A non-zero return with some
+   values could cause a test to incorrectly be considered passing when
+   it really failed.  For this reason, the function should always
+   return 0 (EXIT_SUCCESS), 1 (EXIT_FAILURE), or 77
+   (EXIT_UNSUPPORTED).
+
+   The test function may print out diagnostic or warning messages as well
+   as messages about failures.  These messages should be printed to stdout
+   and not stderr so that the output is properly ordered with respect to
+   the rest of the glibc testsuite run output.
+
+   Several preprocessors macros can be defined before including this
+   file.
+
+   The name of the do_test function can be changed with the
+   TEST_FUNCTION macro.  It must expand to the desired function name.
+
+   If the test case needs access to command line parameters, it must
+   define the TEST_FUNCTION_ARGV macro with the name of the test
+   function.  It must have the following type:
+
+     int TEST_FUNCTION_ARGV (int argc, char **argv);
+
+   This overrides the do_test default function and is incompatible
+   with the TEST_FUNCTION macro.
+
+   If PREPARE is defined, it must expand to the name of a function of
+   the type
+
+     void PREPARE (int argc, char **);
+
+   This function will be called early, after parsing the command line,
+   but before running the test, in the parent process which acts as
+   the test supervisor.
+
+   If CLEANUP_HANDLER is defined, it must expand to the name of a
+   function of the type
+
+     void CLEANUP_HANDLER (void);
+
+   This function will be called from the timeout (SIGALRM) signal
+   handler.
+
+   If TIMEOUT is defined, it must be positive constant.  It overrides
+   the default test timeout and is measured in seconds.
+*/
+#include "test-driver.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <error.h>
+#include <getopt.h>
+#include <malloc.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+/* The PID of the test process.  */
+static pid_t test_pid;
+
+static void *delayed_exit_thread(void *seconds_as_ptr)
+{
+	int seconds = (uintptr_t) seconds_as_ptr;
+	struct timespec delay = { seconds, 0 };
+	struct timespec remaining = { 0 };
+	int err;
+
+	err = nanosleep(&delay, &remaining);
+	if (err != 0)
+		error(EXIT_FAILURE, err,
+		      "delayed_exit_thread: nanosleep failed");
+
+	/* Exit the process sucessfully.  */
+	exit(0);
+	return NULL;
+}
+
+void delayed_exit(int seconds)
+{
+	/* Create the new thread with all signals blocked.  */
+	sigset_t all_blocked;
+	sigfillset(&all_blocked);
+	sigset_t old_set;
+	pthread_t thr;
+	int err;
+
+	err = pthread_sigmask(SIG_SETMASK, &all_blocked, &old_set);
+	if (err != 0)
+		error(EXIT_FAILURE, err,
+		      "delayed_exit: failed to set signal mask");
+
+	/* Create a detached thread. */
+
+	err = pthread_create(&thr, NULL, delayed_exit_thread,
+			     (void *)(uintptr_t) seconds);
+	if (err != 0)
+		error(EXIT_FAILURE, err,
+		      "delayed_exit: failed to create delayed thread");
+
+	err = pthread_detach(thr);
+	if (err != 0)
+		error(EXIT_FAILURE, err,
+		      "delayed_exit: failed to detach thread");
+
+	/* Restore the original signal mask.  */
+	err = pthread_sigmask(SIG_SETMASK, &old_set, NULL);
+	if (err != 0)
+		error(EXIT_FAILURE, err,
+		      "delayed_exit: failed to set signal mask");
+}
+
+/* The cleanup handler passed to test_main.  */
+static void (*cleanup_function) (void);
+
+/* Timeout handler.  We kill the child and exit with an error.  */
+static void
+    __attribute__ ((noreturn))
+    signal_handler(int sig)
+{
+	int killed;
+	int status;
+	int i;
+
+	assert(test_pid > 1);
+	/* Kill the whole process group.  */
+	kill(-test_pid, SIGKILL);
+	/* In case setpgid failed in the child, kill it individually too.  */
+	kill(test_pid, SIGKILL);
+
+	/* Wait for it to terminate.  */
+	for (i = 0; i < 5; ++i) {
+		killed = waitpid(test_pid, &status, WNOHANG | WUNTRACED);
+		if (killed != 0)
+			break;
+
+		/* Delay, give the system time to process the kill.  If the
+		   nanosleep() call return prematurely, all the better.  We
+		   won't restart it since this probably means the child process
+		   finally died.  */
+		struct timespec ts;
+		ts.tv_sec = 0;
+		ts.tv_nsec = 100000000;
+		nanosleep(&ts, NULL);
+	}
+	if (killed != 0 && killed != test_pid) {
+		printf("Failed to kill test process: %m\n");
+		exit(1);
+	}
+
+	if (cleanup_function != NULL)
+		cleanup_function();
+
+	if (sig == SIGINT) {
+		signal(sig, SIG_DFL);
+		raise(sig);
+	}
+
+	if (killed == 0 || (WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL))
+		puts("Timed out: killed the child process");
+	else if (WIFSTOPPED(status))
+		printf("Timed out: the child process was %s\n",
+		       strsignal(WSTOPSIG(status)));
+	else if (WIFSIGNALED(status))
+		printf("Timed out: the child process got signal %s\n",
+		       strsignal(WTERMSIG(status)));
+	else
+		printf("Timed out: killed the child process but it exited %d\n",
+		       WEXITSTATUS(status));
+
+	/* Exit with an error.  */
+	exit(1);
+}
+
+/* Run test_function or test_function_argv.  */
+static int
+run_test_function(int argc, char **argv, const struct test_config *config)
+{
+	if (config->test_function != NULL)
+		return config->test_function();
+	else if (config->test_function_argv != NULL)
+		return config->test_function_argv(argc, argv);
+	else {
+		printf("error: no test function defined\n");
+		exit(1);
+	}
+}
+
+static bool test_main_called;
+const char *test_dir = NULL;
+
+static int support_test_main(int argc, char **argv, const struct test_config *config)
+{
+	pid_t termpid;
+	int status;
+
+	if (test_main_called) {
+		printf("error: test_main called for a second time\n");
+		exit(1);
+	}
+	test_main_called = true;
+
+	cleanup_function = config->cleanup_function;
+
+	if (mallopt != NULL)
+		mallopt(M_PERTURB, 42);
+
+	/* Set TMPDIR to specified test directory.  */
+	test_dir = getenv("TMPDIR");
+	if (test_dir == NULL || test_dir[0] == '\0')
+		test_dir = "/tmp";
+
+	int timeout = config->timeout;
+	if (timeout == 0)
+		timeout = DEFAULT_TIMEOUT;
+
+	/* Make sure we see all message, even those on stdout.  */
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	/* Call the initializing function, if one is available.  */
+	if (config->prepare_function != NULL)
+		config->prepare_function(argc, argv);
+
+	test_pid = fork();
+	if (test_pid == 0) {
+		/* We put the test process in its own pgrp so that if it bogusly
+		   generates any job control signals, they won't hit the whole
+		   build.  */
+		if (setpgid(0, 0) != 0)
+			printf("Failed to set the process group ID: %m\n");
+
+		/* Execute the test function and exit with the return value. */
+		exit(run_test_function(argc, argv, config));
+	} else if (test_pid < 0) {
+		printf("Cannot fork test program: %m\n");
+		exit(1);
+	}
+
+	/* Set timeout.  */
+	signal(SIGALRM, signal_handler);
+	alarm(timeout);
+
+	/* Make sure we clean up if the wrapper gets interrupted.  */
+	signal(SIGINT, signal_handler);
+
+	/* Wait for the regular termination.  */
+	do {
+		termpid = waitpid(test_pid, &status, 0);
+	} while (termpid < 0 && errno == EINTR);
+
+	if (termpid == -1) {
+		printf("Waiting for test program failed: %m\n");
+		exit(1);
+	}
+	if (termpid != test_pid) {
+		printf
+		    ("Oops, wrong test program terminated: expected %ld, got %ld\n",
+		     (long int)test_pid, (long int)termpid);
+		exit(1);
+	}
+
+	/* Process terminated normaly without timeout etc.  */
+	if (WIFEXITED(status)) {
+		/* Exit with the return value of the test.  */
+		return WEXITSTATUS(status);
+	} else {
+		/* Process was killed by timer or other signal.  */
+		printf("Didn't expect signal from child: got `%s'\n",
+		       strsignal(WTERMSIG(status)));
+		exit(1);
+	}
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct test_config test_config;
+	memset(&test_config, 0, sizeof(test_config));
+
+#ifdef PREPARE
+	test_config.prepare_function = (PREPARE);
+#endif
+
+#if defined (TEST_FUNCTION) && defined (TEST_FUNCTON_ARGV)
+#error TEST_FUNCTION and TEST_FUNCTION_ARGV cannot be defined at the same time
+#endif
+#if defined (TEST_FUNCTION)
+	test_config.test_function = TEST_FUNCTION;
+#elif defined (TEST_FUNCTION_ARGV)
+	test_config.test_function_argv = TEST_FUNCTION_ARGV;
+#else
+	test_config.test_function = do_test;
+#endif
+
+#ifdef CLEANUP_HANDLER
+	test_config.cleanup_function = CLEANUP_HANDLER;
+#endif
+
+#ifdef TIMEOUT
+	test_config.timeout = TIMEOUT;
+#endif
+
+	return support_test_main(argc, argv, &test_config);
+}

--- a/tests/glibc-tests/test-driver.h
+++ b/tests/glibc-tests/test-driver.h
@@ -1,0 +1,55 @@
+/* Interfaces for the test driver.
+   Copyright (C) 2016-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef SUPPORT_TEST_DRIVER_H
+#define SUPPORT_TEST_DRIVER_H
+
+#include <stdlib.h>
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS struct test_config {
+	void (*prepare_function) (int argc, char **argv);
+	int (*test_function) (void);
+	int (*test_function_argv) (int argc, char **argv);
+	void (*cleanup_function) (void);
+	const void *options;	/* Custom options if not NULL.  */
+	int timeout;		/* Test timeout in seconds.  */
+};
+
+enum {
+	/* Test exit status which indicates that the feature is
+	   unsupported. */
+	EXIT_UNSUPPORTED = 77,
+
+	/* Default timeout is twenty seconds.  Tests should normally
+	   complete faster than this, but if they don't, that's abnormal
+	   (a bug) anyways.  */
+	DEFAULT_TIMEOUT = 20,
+};
+
+#define SKIP_TEST(reason)					\
+	do {							\
+		printf("test skipped due to: %s\n", reason);	\
+		exit(EXIT_UNSUPPORTED);				\
+	} while(0);
+
+/* The directory the test should use for temporary files.  */
+extern const char *test_dir;
+
+__END_DECLS
+#endif /* SUPPORT_TEST_DRIVER_H */

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -1,0 +1,109 @@
+/* Verify that exception table for pthread_cond_wait is correct.
+   Copyright (C) 2012-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+pthread_mutex_t mutex;
+pthread_cond_t cond;
+
+#define CHECK_RETURN_VAL_OR_FAIL(ret,str) \
+  ({ if ((ret) != 0) \
+       { \
+         printf ("%s failed: %s\n", (str), strerror (ret)); \
+         ret = 1; \
+         goto out; \
+       } \
+  })
+
+
+void
+clean (void *arg)
+{
+  puts ("clean: Unlocking mutex...");
+  pthread_mutex_unlock ((pthread_mutex_t *) arg);
+  puts ("clean: Mutex unlocked...");
+}
+
+void *
+thr (void *arg)
+{
+  int ret = 0;
+  pthread_mutexattr_t mutexAttr;
+  ret = pthread_mutexattr_init (&mutexAttr);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutexattr_init");
+
+  ret = pthread_mutexattr_setprotocol (&mutexAttr, PTHREAD_PRIO_INHERIT);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutexattr_setprotocol");
+
+  ret = pthread_mutex_init (&mutex, &mutexAttr);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutex_init");
+
+  ret = pthread_cond_init (&cond, 0);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cond_init");
+
+  puts ("th: Init done, entering wait...");
+
+  pthread_cleanup_push (clean, (void *) &mutex);
+  ret = pthread_mutex_lock (&mutex);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutex_lock");
+  while (1)
+    {
+      ret = pthread_cond_wait (&cond, &mutex);
+      CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cond_wait");
+    }
+  pthread_cleanup_pop (1);
+
+out:
+  return (void *) (uintptr_t) ret;
+}
+
+int
+do_test (void)
+{
+  pthread_t thread;
+  int ret = 0;
+  void *thr_ret = 0;
+  ret = pthread_create (&thread, 0, thr, &thr_ret);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_create");
+
+  puts ("main: Thread created, waiting a bit...");
+  sleep (2);
+
+  puts ("main: Cancelling thread...");
+  ret = pthread_cancel (thread);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cancel");
+
+  puts ("main: Joining th...");
+  ret = pthread_join (thread, NULL);
+  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_join");
+
+  if (thr_ret != NULL)
+    return 1;
+
+  puts ("main: Joined thread, done!");
+
+out:
+  return ret;
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -100,5 +100,4 @@ out:
 	return ret;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -34,75 +34,70 @@ pthread_cond_t cond;
        } \
   })
 
-
-void
-clean (void *arg)
+void clean(void *arg)
 {
-  puts ("clean: Unlocking mutex...");
-  pthread_mutex_unlock ((pthread_mutex_t *) arg);
-  puts ("clean: Mutex unlocked...");
+	puts("clean: Unlocking mutex...");
+	pthread_mutex_unlock((pthread_mutex_t *) arg);
+	puts("clean: Mutex unlocked...");
 }
 
-void *
-thr (void *arg)
+void *thr(void *arg)
 {
-  int ret = 0;
-  pthread_mutexattr_t mutexAttr;
-  ret = pthread_mutexattr_init (&mutexAttr);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutexattr_init");
+	int ret = 0;
+	pthread_mutexattr_t mutexAttr;
+	ret = pthread_mutexattr_init(&mutexAttr);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutexattr_init");
 
-  ret = pthread_mutexattr_setprotocol (&mutexAttr, PTHREAD_PRIO_INHERIT);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutexattr_setprotocol");
+	ret = pthread_mutexattr_setprotocol(&mutexAttr, PTHREAD_PRIO_INHERIT);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutexattr_setprotocol");
 
-  ret = pthread_mutex_init (&mutex, &mutexAttr);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutex_init");
+	ret = pthread_mutex_init(&mutex, &mutexAttr);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutex_init");
 
-  ret = pthread_cond_init (&cond, 0);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cond_init");
+	ret = pthread_cond_init(&cond, 0);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_cond_init");
 
-  puts ("th: Init done, entering wait...");
+	puts("th: Init done, entering wait...");
 
-  pthread_cleanup_push (clean, (void *) &mutex);
-  ret = pthread_mutex_lock (&mutex);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_mutex_lock");
-  while (1)
-    {
-      ret = pthread_cond_wait (&cond, &mutex);
-      CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cond_wait");
-    }
-  pthread_cleanup_pop (1);
+	pthread_cleanup_push(clean, (void *)&mutex);
+	ret = pthread_mutex_lock(&mutex);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutex_lock");
+	while (1) {
+		ret = pthread_cond_wait(&cond, &mutex);
+		CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_cond_wait");
+	}
+	pthread_cleanup_pop(1);
 
 out:
-  return (void *) (uintptr_t) ret;
+	return (void *)(uintptr_t) ret;
 }
 
-int
-do_test (void)
+int do_test(void)
 {
-  pthread_t thread;
-  int ret = 0;
-  void *thr_ret = 0;
-  ret = pthread_create (&thread, 0, thr, &thr_ret);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_create");
+	pthread_t thread;
+	int ret = 0;
+	void *thr_ret = 0;
+	ret = pthread_create(&thread, 0, thr, &thr_ret);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_create");
 
-  puts ("main: Thread created, waiting a bit...");
-  sleep (2);
+	puts("main: Thread created, waiting a bit...");
+	sleep(2);
 
-  puts ("main: Cancelling thread...");
-  ret = pthread_cancel (thread);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_cancel");
+	puts("main: Cancelling thread...");
+	ret = pthread_cancel(thread);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_cancel");
 
-  puts ("main: Joining th...");
-  ret = pthread_join (thread, NULL);
-  CHECK_RETURN_VAL_OR_FAIL (ret, "pthread_join");
+	puts("main: Joining th...");
+	ret = pthread_join(thread, NULL);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_join");
 
-  if (thr_ret != NULL)
-    return 1;
+	if (thr_ret != NULL)
+		return 1;
 
-  puts ("main: Joined thread, done!");
+	puts("main: Joined thread, done!");
 
 out:
-  return ret;
+	return ret;
 }
 
 #define TEST_FUNCTION do_test ()

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -1,0 +1,96 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <error.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+
+
+static void *
+tf (void *p)
+{
+  int err;
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "child: cannot get mutex");
+
+  puts ("child: got mutex; signalling");
+
+  pthread_cond_signal (&cond);
+
+  puts ("child: unlock");
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "child: cannot unlock");
+
+  puts ("child: done");
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  pthread_t th;
+  int err;
+
+  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+
+  puts ("parent: get mutex");
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: cannot get mutex");
+
+  puts ("parent: create child");
+
+  err = pthread_create (&th, NULL, tf, NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: cannot create thread");
+
+  puts ("parent: wait for condition");
+
+  /* This test will fail on spurious wake-ups, which are allowed; however,
+     the current implementation shouldn't produce spurious wake-ups in the
+     scenario we are testing here.  */
+  err = pthread_cond_wait (&cond, &mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: cannot wait fir signal");
+
+  puts ("parent: got signal");
+
+  err = pthread_join (th, NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to join");
+
+  puts ("done");
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -86,5 +86,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -21,76 +21,70 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 
-
-static void *
-tf (void *p)
+static void *tf(void *p)
 {
-  int err;
+	int err;
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "child: cannot get mutex");
+	err = pthread_mutex_lock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "child: cannot get mutex");
 
-  puts ("child: got mutex; signalling");
+	puts("child: got mutex; signalling");
 
-  pthread_cond_signal (&cond);
+	pthread_cond_signal(&cond);
 
-  puts ("child: unlock");
+	puts("child: unlock");
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "child: cannot unlock");
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "child: cannot unlock");
 
-  puts ("child: done");
+	puts("child: done");
 
-  return NULL;
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  pthread_t th;
-  int err;
+	pthread_t th;
+	int err;
 
-  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+	printf("&cond = %p\n&mut = %p\n", &cond, &mut);
 
-  puts ("parent: get mutex");
+	puts("parent: get mutex");
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: cannot get mutex");
+	err = pthread_mutex_lock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "parent: cannot get mutex");
 
-  puts ("parent: create child");
+	puts("parent: create child");
 
-  err = pthread_create (&th, NULL, tf, NULL);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: cannot create thread");
+	err = pthread_create(&th, NULL, tf, NULL);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "parent: cannot create thread");
 
-  puts ("parent: wait for condition");
+	puts("parent: wait for condition");
 
-  /* This test will fail on spurious wake-ups, which are allowed; however,
-     the current implementation shouldn't produce spurious wake-ups in the
-     scenario we are testing here.  */
-  err = pthread_cond_wait (&cond, &mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: cannot wait fir signal");
+	/* This test will fail on spurious wake-ups, which are allowed; however,
+	   the current implementation shouldn't produce spurious wake-ups in the
+	   scenario we are testing here.  */
+	err = pthread_cond_wait(&cond, &mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "parent: cannot wait fir signal");
 
-  puts ("parent: got signal");
+	puts("parent: got signal");
 
-  err = pthread_join (th, NULL);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: failed to join");
+	err = pthread_join(th, NULL);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "parent: failed to join");
 
-  puts ("done");
+	puts("done");
 
-  return 0;
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -1,0 +1,172 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <error.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define N 10
+#define ROUNDS 100
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pthread_barrier_t bN1;
+static pthread_barrier_t b2;
+
+
+static void *
+tf (void *p)
+{
+  if (pthread_mutex_lock (&mut) != 0)
+    {
+      puts ("child: 1st mutex_lock failed");
+      exit (1);
+    }
+
+  int e = pthread_barrier_wait (&b2);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("child: 1st barrier_wait failed");
+      exit (1);
+    }
+
+  if (pthread_cond_wait (&cond, &mut) != 0)
+    {
+      puts ("child: cond_wait failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_unlock (&mut) != 0)
+    {
+      puts ("child: mutex_unlock failed");
+      exit (1);
+    }
+
+  e = pthread_barrier_wait (&bN1);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("child: 2nd barrier_wait failed");
+      exit (1);
+    }
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  if (pthread_barrier_init (&bN1, NULL, N + 1) != 0)
+    {
+      puts ("barrier_init failed");
+      exit (1);
+    }
+
+  if (pthread_barrier_init (&b2, NULL, 2) != 0)
+    {
+      puts ("barrier_init failed");
+      exit (1);
+    }
+
+  pthread_attr_t at;
+
+  if (pthread_attr_init (&at) != 0)
+    {
+      puts ("attr_init failed");
+      return 1;
+    }
+
+  if (pthread_attr_setstacksize (&at, 1 * 1024 * 1024) != 0)
+    {
+      puts ("attr_setstacksize failed");
+      return 1;
+    }
+
+  int r;
+  for (r = 0; r < ROUNDS; ++r)
+    {
+      printf ("round %d\n", r + 1);
+
+      int i;
+      pthread_t th[N];
+      for (i = 0; i < N; ++i)
+	{
+	  if (pthread_create (&th[i], &at, tf, NULL) != 0)
+	    {
+	      puts ("create failed");
+	      exit (1);
+	    }
+
+	  int e = pthread_barrier_wait (&b2);
+	  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+	    {
+	      puts ("parent: 1st barrier_wait failed");
+	      exit (1);
+	    }
+	}
+
+      if (pthread_mutex_lock (&mut) != 0)
+	{
+	  puts ("parent: mutex_lock failed");
+	  exit (1);
+	}
+      if (pthread_mutex_unlock (&mut) != 0)
+	{
+	  puts ("parent: mutex_unlock failed");
+	  exit (1);
+	}
+
+      /* N single signal calls.  Without locking.  This tests that no
+	 signal gets lost.  */
+      for (i = 0; i < N; ++i)
+	if (pthread_cond_signal (&cond) != 0)
+	  {
+	    puts ("cond_signal failed");
+	    exit (1);
+	  }
+
+      int e = pthread_barrier_wait (&bN1);
+      if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("parent: 2nd barrier_wait failed");
+	  exit (1);
+	}
+
+      for (i = 0; i < N; ++i)
+	if (pthread_join (th[i], NULL) != 0)
+	  {
+	    puts ("join failed");
+	    exit (1);
+	  }
+    }
+
+  if (pthread_attr_destroy (&at) != 0)
+    {
+      puts ("attr_destroy failed");
+      return 1;
+    }
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -143,5 +143,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 #define N 10
 #define ROUNDS 100
 
@@ -31,142 +30,118 @@ static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 static pthread_barrier_t bN1;
 static pthread_barrier_t b2;
 
-
-static void *
-tf (void *p)
+static void *tf(void *p)
 {
-  if (pthread_mutex_lock (&mut) != 0)
-    {
-      puts ("child: 1st mutex_lock failed");
-      exit (1);
-    }
+	if (pthread_mutex_lock(&mut) != 0) {
+		puts("child: 1st mutex_lock failed");
+		exit(1);
+	}
 
-  int e = pthread_barrier_wait (&b2);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("child: 1st barrier_wait failed");
-      exit (1);
-    }
+	int e = pthread_barrier_wait(&b2);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("child: 1st barrier_wait failed");
+		exit(1);
+	}
 
-  if (pthread_cond_wait (&cond, &mut) != 0)
-    {
-      puts ("child: cond_wait failed");
-      exit (1);
-    }
+	if (pthread_cond_wait(&cond, &mut) != 0) {
+		puts("child: cond_wait failed");
+		exit(1);
+	}
 
-  if (pthread_mutex_unlock (&mut) != 0)
-    {
-      puts ("child: mutex_unlock failed");
-      exit (1);
-    }
+	if (pthread_mutex_unlock(&mut) != 0) {
+		puts("child: mutex_unlock failed");
+		exit(1);
+	}
 
-  e = pthread_barrier_wait (&bN1);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("child: 2nd barrier_wait failed");
-      exit (1);
-    }
+	e = pthread_barrier_wait(&bN1);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("child: 2nd barrier_wait failed");
+		exit(1);
+	}
 
-  return NULL;
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  if (pthread_barrier_init (&bN1, NULL, N + 1) != 0)
-    {
-      puts ("barrier_init failed");
-      exit (1);
-    }
-
-  if (pthread_barrier_init (&b2, NULL, 2) != 0)
-    {
-      puts ("barrier_init failed");
-      exit (1);
-    }
-
-  pthread_attr_t at;
-
-  if (pthread_attr_init (&at) != 0)
-    {
-      puts ("attr_init failed");
-      return 1;
-    }
-
-  if (pthread_attr_setstacksize (&at, 1 * 1024 * 1024) != 0)
-    {
-      puts ("attr_setstacksize failed");
-      return 1;
-    }
-
-  int r;
-  for (r = 0; r < ROUNDS; ++r)
-    {
-      printf ("round %d\n", r + 1);
-
-      int i;
-      pthread_t th[N];
-      for (i = 0; i < N; ++i)
-	{
-	  if (pthread_create (&th[i], &at, tf, NULL) != 0)
-	    {
-	      puts ("create failed");
-	      exit (1);
-	    }
-
-	  int e = pthread_barrier_wait (&b2);
-	  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-	    {
-	      puts ("parent: 1st barrier_wait failed");
-	      exit (1);
-	    }
+	if (pthread_barrier_init(&bN1, NULL, N + 1) != 0) {
+		puts("barrier_init failed");
+		exit(1);
 	}
 
-      if (pthread_mutex_lock (&mut) != 0)
-	{
-	  puts ("parent: mutex_lock failed");
-	  exit (1);
-	}
-      if (pthread_mutex_unlock (&mut) != 0)
-	{
-	  puts ("parent: mutex_unlock failed");
-	  exit (1);
+	if (pthread_barrier_init(&b2, NULL, 2) != 0) {
+		puts("barrier_init failed");
+		exit(1);
 	}
 
-      /* N single signal calls.  Without locking.  This tests that no
-	 signal gets lost.  */
-      for (i = 0; i < N; ++i)
-	if (pthread_cond_signal (&cond) != 0)
-	  {
-	    puts ("cond_signal failed");
-	    exit (1);
-	  }
+	pthread_attr_t at;
 
-      int e = pthread_barrier_wait (&bN1);
-      if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("parent: 2nd barrier_wait failed");
-	  exit (1);
+	if (pthread_attr_init(&at) != 0) {
+		puts("attr_init failed");
+		return 1;
 	}
 
-      for (i = 0; i < N; ++i)
-	if (pthread_join (th[i], NULL) != 0)
-	  {
-	    puts ("join failed");
-	    exit (1);
-	  }
-    }
+	if (pthread_attr_setstacksize(&at, 1 * 1024 * 1024) != 0) {
+		puts("attr_setstacksize failed");
+		return 1;
+	}
 
-  if (pthread_attr_destroy (&at) != 0)
-    {
-      puts ("attr_destroy failed");
-      return 1;
-    }
+	int r;
+	for (r = 0; r < ROUNDS; ++r) {
+		printf("round %d\n", r + 1);
 
-  return 0;
+		int i;
+		pthread_t th[N];
+		for (i = 0; i < N; ++i) {
+			if (pthread_create(&th[i], &at, tf, NULL) != 0) {
+				puts("create failed");
+				exit(1);
+			}
+
+			int e = pthread_barrier_wait(&b2);
+			if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+				puts("parent: 1st barrier_wait failed");
+				exit(1);
+			}
+		}
+
+		if (pthread_mutex_lock(&mut) != 0) {
+			puts("parent: mutex_lock failed");
+			exit(1);
+		}
+		if (pthread_mutex_unlock(&mut) != 0) {
+			puts("parent: mutex_unlock failed");
+			exit(1);
+		}
+
+		/* N single signal calls.  Without locking.  This tests that no
+		   signal gets lost.  */
+		for (i = 0; i < N; ++i)
+			if (pthread_cond_signal(&cond) != 0) {
+				puts("cond_signal failed");
+				exit(1);
+			}
+
+		int e = pthread_barrier_wait(&bN1);
+		if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("parent: 2nd barrier_wait failed");
+			exit(1);
+		}
+
+		for (i = 0; i < N; ++i)
+			if (pthread_join(th[i], NULL) != 0) {
+				puts("join failed");
+				exit(1);
+			}
+	}
+
+	if (pthread_attr_destroy(&at) != 0) {
+		puts("attr_destroy failed");
+		return 1;
+	}
+
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -1,0 +1,203 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+
+#if defined _POSIX_CLOCK_SELECTION && _POSIX_CLOCK_SELECTION >= 0
+static int
+run_test (clockid_t cl)
+{
+  pthread_condattr_t condattr;
+  pthread_cond_t cond;
+  pthread_mutexattr_t mutattr;
+  pthread_mutex_t mut;
+
+  printf ("clock = %d\n", (int) cl);
+
+  if (pthread_condattr_init (&condattr) != 0)
+    {
+      puts ("condattr_init failed");
+      return 1;
+    }
+
+  if (pthread_condattr_setclock (&condattr, cl) != 0)
+    {
+      puts ("condattr_setclock failed");
+      return 1;
+    }
+
+  clockid_t cl2;
+  if (pthread_condattr_getclock (&condattr, &cl2) != 0)
+    {
+      puts ("condattr_getclock failed");
+      return 1;
+    }
+  if (cl != cl2)
+    {
+      printf ("condattr_getclock returned wrong value: %d, expected %d\n",
+	      (int) cl2, (int) cl);
+      return 1;
+    }
+
+  if (pthread_cond_init (&cond, &condattr) != 0)
+    {
+      puts ("cond_init failed");
+      return 1;
+    }
+
+  if (pthread_condattr_destroy (&condattr) != 0)
+    {
+      puts ("condattr_destroy failed");
+      return 1;
+    }
+
+  if (pthread_mutexattr_init (&mutattr) != 0)
+    {
+      puts ("mutexattr_init failed");
+      return 1;
+    }
+
+  if (pthread_mutexattr_settype (&mutattr, PTHREAD_MUTEX_ERRORCHECK) != 0)
+    {
+      puts ("mutexattr_settype failed");
+      return 1;
+    }
+
+  if (pthread_mutex_init (&mut, &mutattr) != 0)
+    {
+      puts ("mutex_init failed");
+      return 1;
+    }
+
+  if (pthread_mutexattr_destroy (&mutattr) != 0)
+    {
+      puts ("mutexattr_destroy failed");
+      return 1;
+    }
+
+  if (pthread_mutex_lock (&mut) != 0)
+    {
+      puts ("mutex_lock failed");
+      return 1;
+    }
+
+  if (pthread_mutex_lock (&mut) != EDEADLK)
+    {
+      puts ("2nd mutex_lock did not return EDEADLK");
+      return 1;
+    }
+
+  struct timespec ts;
+  if (clock_gettime (cl, &ts) != 0)
+    {
+      puts ("clock_gettime failed");
+      return 1;
+    }
+
+  /* Wait one second.  */
+  ++ts.tv_sec;
+
+  int e = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (e == 0)
+    {
+      puts ("cond_timedwait succeeded");
+      return 1;
+    }
+  else if (e != ETIMEDOUT)
+    {
+      puts ("cond_timedwait did not return ETIMEDOUT");
+      return 1;
+    }
+
+  struct timespec ts2;
+  if (clock_gettime (cl, &ts2) != 0)
+    {
+      puts ("second clock_gettime failed");
+      return 1;
+    }
+
+  if (ts2.tv_sec < ts.tv_sec
+      || (ts2.tv_sec == ts.tv_sec && ts2.tv_nsec < ts.tv_nsec))
+    {
+      puts ("timeout too short");
+      return 1;
+    }
+
+  if (pthread_mutex_unlock (&mut) != 0)
+    {
+      puts ("mutex_unlock failed");
+      return 1;
+    }
+
+  if (pthread_mutex_destroy (&mut) != 0)
+    {
+      puts ("mutex_destroy failed");
+      return 1;
+    }
+
+  if (pthread_cond_destroy (&cond) != 0)
+    {
+      puts ("cond_destroy failed");
+      return 1;
+    }
+
+  return 0;
+}
+#endif
+
+
+static int
+do_test (void)
+{
+#if !defined _POSIX_CLOCK_SELECTION || _POSIX_CLOCK_SELECTION == -1
+
+  puts ("_POSIX_CLOCK_SELECTION not supported, test skipped");
+  return 0;
+
+#else
+
+  int res = run_test (CLOCK_REALTIME);
+
+# if defined _POSIX_MONOTONIC_CLOCK && _POSIX_MONOTONIC_CLOCK >= 0
+#  if _POSIX_MONOTONIC_CLOCK == 0
+  int e = sysconf (_SC_MONOTONIC_CLOCK);
+  if (e < 0)
+    puts ("CLOCK_MONOTONIC not supported");
+  else if (e == 0)
+    {
+      puts ("sysconf (_SC_MONOTONIC_CLOCK) must not return 0");
+      res = 1;
+    }
+  else
+#  endif
+    res |= run_test (CLOCK_MONOTONIC);
+# else
+  puts ("_POSIX_MONOTONIC_CLOCK not defined");
+# endif
+
+  return res;
+#endif
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -22,180 +22,154 @@
 #include <time.h>
 #include <unistd.h>
 
-
 #if defined _POSIX_CLOCK_SELECTION && _POSIX_CLOCK_SELECTION >= 0
-static int
-run_test (clockid_t cl)
+static int run_test(clockid_t cl)
 {
-  pthread_condattr_t condattr;
-  pthread_cond_t cond;
-  pthread_mutexattr_t mutattr;
-  pthread_mutex_t mut;
+	pthread_condattr_t condattr;
+	pthread_cond_t cond;
+	pthread_mutexattr_t mutattr;
+	pthread_mutex_t mut;
 
-  printf ("clock = %d\n", (int) cl);
+	printf("clock = %d\n", (int)cl);
 
-  if (pthread_condattr_init (&condattr) != 0)
-    {
-      puts ("condattr_init failed");
-      return 1;
-    }
+	if (pthread_condattr_init(&condattr) != 0) {
+		puts("condattr_init failed");
+		return 1;
+	}
 
-  if (pthread_condattr_setclock (&condattr, cl) != 0)
-    {
-      puts ("condattr_setclock failed");
-      return 1;
-    }
+	if (pthread_condattr_setclock(&condattr, cl) != 0) {
+		puts("condattr_setclock failed");
+		return 1;
+	}
 
-  clockid_t cl2;
-  if (pthread_condattr_getclock (&condattr, &cl2) != 0)
-    {
-      puts ("condattr_getclock failed");
-      return 1;
-    }
-  if (cl != cl2)
-    {
-      printf ("condattr_getclock returned wrong value: %d, expected %d\n",
-	      (int) cl2, (int) cl);
-      return 1;
-    }
+	clockid_t cl2;
+	if (pthread_condattr_getclock(&condattr, &cl2) != 0) {
+		puts("condattr_getclock failed");
+		return 1;
+	}
+	if (cl != cl2) {
+		printf
+		    ("condattr_getclock returned wrong value: %d, expected %d\n",
+		     (int)cl2, (int)cl);
+		return 1;
+	}
 
-  if (pthread_cond_init (&cond, &condattr) != 0)
-    {
-      puts ("cond_init failed");
-      return 1;
-    }
+	if (pthread_cond_init(&cond, &condattr) != 0) {
+		puts("cond_init failed");
+		return 1;
+	}
 
-  if (pthread_condattr_destroy (&condattr) != 0)
-    {
-      puts ("condattr_destroy failed");
-      return 1;
-    }
+	if (pthread_condattr_destroy(&condattr) != 0) {
+		puts("condattr_destroy failed");
+		return 1;
+	}
 
-  if (pthread_mutexattr_init (&mutattr) != 0)
-    {
-      puts ("mutexattr_init failed");
-      return 1;
-    }
+	if (pthread_mutexattr_init(&mutattr) != 0) {
+		puts("mutexattr_init failed");
+		return 1;
+	}
 
-  if (pthread_mutexattr_settype (&mutattr, PTHREAD_MUTEX_ERRORCHECK) != 0)
-    {
-      puts ("mutexattr_settype failed");
-      return 1;
-    }
+	if (pthread_mutexattr_settype(&mutattr, PTHREAD_MUTEX_ERRORCHECK) != 0) {
+		puts("mutexattr_settype failed");
+		return 1;
+	}
 
-  if (pthread_mutex_init (&mut, &mutattr) != 0)
-    {
-      puts ("mutex_init failed");
-      return 1;
-    }
+	if (pthread_mutex_init(&mut, &mutattr) != 0) {
+		puts("mutex_init failed");
+		return 1;
+	}
 
-  if (pthread_mutexattr_destroy (&mutattr) != 0)
-    {
-      puts ("mutexattr_destroy failed");
-      return 1;
-    }
+	if (pthread_mutexattr_destroy(&mutattr) != 0) {
+		puts("mutexattr_destroy failed");
+		return 1;
+	}
 
-  if (pthread_mutex_lock (&mut) != 0)
-    {
-      puts ("mutex_lock failed");
-      return 1;
-    }
+	if (pthread_mutex_lock(&mut) != 0) {
+		puts("mutex_lock failed");
+		return 1;
+	}
 
-  if (pthread_mutex_lock (&mut) != EDEADLK)
-    {
-      puts ("2nd mutex_lock did not return EDEADLK");
-      return 1;
-    }
+	if (pthread_mutex_lock(&mut) != EDEADLK) {
+		puts("2nd mutex_lock did not return EDEADLK");
+		return 1;
+	}
 
-  struct timespec ts;
-  if (clock_gettime (cl, &ts) != 0)
-    {
-      puts ("clock_gettime failed");
-      return 1;
-    }
+	struct timespec ts;
+	if (clock_gettime(cl, &ts) != 0) {
+		puts("clock_gettime failed");
+		return 1;
+	}
 
-  /* Wait one second.  */
-  ++ts.tv_sec;
+	/* Wait one second.  */
+	++ts.tv_sec;
 
-  int e = pthread_cond_timedwait (&cond, &mut, &ts);
-  if (e == 0)
-    {
-      puts ("cond_timedwait succeeded");
-      return 1;
-    }
-  else if (e != ETIMEDOUT)
-    {
-      puts ("cond_timedwait did not return ETIMEDOUT");
-      return 1;
-    }
+	int e = pthread_cond_timedwait(&cond, &mut, &ts);
+	if (e == 0) {
+		puts("cond_timedwait succeeded");
+		return 1;
+	} else if (e != ETIMEDOUT) {
+		puts("cond_timedwait did not return ETIMEDOUT");
+		return 1;
+	}
 
-  struct timespec ts2;
-  if (clock_gettime (cl, &ts2) != 0)
-    {
-      puts ("second clock_gettime failed");
-      return 1;
-    }
+	struct timespec ts2;
+	if (clock_gettime(cl, &ts2) != 0) {
+		puts("second clock_gettime failed");
+		return 1;
+	}
 
-  if (ts2.tv_sec < ts.tv_sec
-      || (ts2.tv_sec == ts.tv_sec && ts2.tv_nsec < ts.tv_nsec))
-    {
-      puts ("timeout too short");
-      return 1;
-    }
+	if (ts2.tv_sec < ts.tv_sec
+	    || (ts2.tv_sec == ts.tv_sec && ts2.tv_nsec < ts.tv_nsec)) {
+		puts("timeout too short");
+		return 1;
+	}
 
-  if (pthread_mutex_unlock (&mut) != 0)
-    {
-      puts ("mutex_unlock failed");
-      return 1;
-    }
+	if (pthread_mutex_unlock(&mut) != 0) {
+		puts("mutex_unlock failed");
+		return 1;
+	}
 
-  if (pthread_mutex_destroy (&mut) != 0)
-    {
-      puts ("mutex_destroy failed");
-      return 1;
-    }
+	if (pthread_mutex_destroy(&mut) != 0) {
+		puts("mutex_destroy failed");
+		return 1;
+	}
 
-  if (pthread_cond_destroy (&cond) != 0)
-    {
-      puts ("cond_destroy failed");
-      return 1;
-    }
+	if (pthread_cond_destroy(&cond) != 0) {
+		puts("cond_destroy failed");
+		return 1;
+	}
 
-  return 0;
+	return 0;
 }
 #endif
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
 #if !defined _POSIX_CLOCK_SELECTION || _POSIX_CLOCK_SELECTION == -1
 
-  puts ("_POSIX_CLOCK_SELECTION not supported, test skipped");
-  return 0;
+	puts("_POSIX_CLOCK_SELECTION not supported, test skipped");
+	return 0;
 
 #else
 
-  int res = run_test (CLOCK_REALTIME);
+	int res = run_test(CLOCK_REALTIME);
 
-# if defined _POSIX_MONOTONIC_CLOCK && _POSIX_MONOTONIC_CLOCK >= 0
-#  if _POSIX_MONOTONIC_CLOCK == 0
-  int e = sysconf (_SC_MONOTONIC_CLOCK);
-  if (e < 0)
-    puts ("CLOCK_MONOTONIC not supported");
-  else if (e == 0)
-    {
-      puts ("sysconf (_SC_MONOTONIC_CLOCK) must not return 0");
-      res = 1;
-    }
-  else
-#  endif
-    res |= run_test (CLOCK_MONOTONIC);
-# else
-  puts ("_POSIX_MONOTONIC_CLOCK not defined");
-# endif
+#if defined _POSIX_MONOTONIC_CLOCK && _POSIX_MONOTONIC_CLOCK >= 0
+#if _POSIX_MONOTONIC_CLOCK == 0
+	int e = sysconf(_SC_MONOTONIC_CLOCK);
+	if (e < 0)
+		puts("CLOCK_MONOTONIC not supported");
+	else if (e == 0) {
+		puts("sysconf (_SC_MONOTONIC_CLOCK) must not return 0");
+		res = 1;
+	} else
+#endif
+		res |= run_test(CLOCK_MONOTONIC);
+#else
+	puts("_POSIX_MONOTONIC_CLOCK not defined");
+#endif
 
-  return res;
+	return res;
 #endif
 }
 

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -173,5 +173,4 @@ static int do_test(void)
 #endif
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -1,0 +1,195 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+
+static char fname[] = "/tmp/tst-cond12-XXXXXX";
+static int fd;
+
+
+static void prepare (void);
+#define PREPARE(argc, argv) prepare ()
+
+static int do_test (void);
+#define TEST_FUNCTION do_test ()
+
+#include "../test-skeleton.c"
+
+
+static void
+prepare (void)
+{
+  fd = mkstemp (fname);
+  if (fd == -1)
+    {
+      printf ("mkstemp failed: %m\n");
+      exit (1);
+    }
+  add_temp_file (fname);
+  if (ftruncate (fd, 1000) < 0)
+    {
+      printf ("ftruncate failed: %m\n");
+      exit (1);
+    }
+}
+
+
+static int
+do_test (void)
+{
+  struct
+  {
+    pthread_mutex_t m;
+    pthread_cond_t c;
+    int var;
+  } *p = mmap (NULL, sizeof (*p), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+  if (p == MAP_FAILED)
+    {
+      printf ("initial mmap failed: %m\n");
+      return 1;
+    }
+
+  pthread_mutexattr_t ma;
+  if (pthread_mutexattr_init (&ma) != 0)
+    {
+      puts ("mutexattr_init failed");
+      return 1;
+    }
+  if (pthread_mutexattr_setpshared (&ma, 1) != 0)
+    {
+      puts ("mutexattr_setpshared failed");
+      return 1;
+    }
+  if (pthread_mutex_init (&p->m, &ma) != 0)
+    {
+      puts ("mutex_init failed");
+      return 1;
+    }
+  if (pthread_mutexattr_destroy (&ma) != 0)
+    {
+      puts ("mutexattr_destroy failed");
+      return 1;
+    }
+
+  pthread_condattr_t ca;
+  if (pthread_condattr_init (&ca) != 0)
+    {
+      puts ("condattr_init failed");
+      return 1;
+    }
+  if (pthread_condattr_setpshared (&ca, 1) != 0)
+    {
+      puts ("condattr_setpshared failed");
+      return 1;
+    }
+  if (pthread_cond_init (&p->c, &ca) != 0)
+    {
+      puts ("mutex_init failed");
+      return 1;
+    }
+  if (pthread_condattr_destroy (&ca) != 0)
+    {
+      puts ("condattr_destroy failed");
+      return 1;
+    }
+
+  if (pthread_mutex_lock (&p->m) != 0)
+    {
+      puts ("initial mutex_lock failed");
+      return 1;
+    }
+
+  p->var = 42;
+
+  pid_t pid = fork ();
+  if (pid == -1)
+    {
+      printf ("fork failed: %m\n");
+      return 1;
+    }
+
+  if (pid == 0)
+    {
+      void *oldp = p;
+      p = mmap (NULL, sizeof (*p), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+
+      if (p == oldp)
+	{
+	  puts ("child: mapped to same address");
+	  kill (getppid (), SIGKILL);
+	  exit (1);
+	}
+
+      munmap (oldp, sizeof (*p));
+
+      if (pthread_mutex_lock (&p->m) != 0)
+	{
+	  puts ("child: mutex_lock failed");
+	  kill (getppid (), SIGKILL);
+	  exit (1);
+	}
+
+      p->var = 0;
+
+#ifndef USE_COND_SIGNAL
+      if (pthread_cond_broadcast (&p->c) != 0)
+	{
+	  puts ("child: cond_broadcast failed");
+	  kill (getppid (), SIGKILL);
+	  exit (1);
+	}
+#else
+      if (pthread_cond_signal (&p->c) != 0)
+	{
+	  puts ("child: cond_signal failed");
+	  kill (getppid (), SIGKILL);
+	  exit (1);
+	}
+#endif
+
+      if (pthread_mutex_unlock (&p->m) != 0)
+	{
+	  puts ("child: mutex_unlock failed");
+	  kill (getppid (), SIGKILL);
+	  exit (1);
+	}
+
+      exit (0);
+    }
+
+  do
+    pthread_cond_wait (&p->c, &p->m);
+  while (p->var != 0);
+
+  if (TEMP_FAILURE_RETRY (waitpid (pid, NULL, 0)) != pid)
+    {
+      printf ("waitpid failed: %m\n");
+      kill (pid, SIGKILL);
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -168,3 +168,7 @@ static int do_test(void)
 
 	return 0;
 }
+
+#define PREPARE prepare
+#define CLEANUP_HANDLER cleanup
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -25,171 +25,146 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 
-
 static char fname[] = "/tmp/tst-cond12-XXXXXX";
 static int fd;
 
-
-static void prepare (void);
+static void prepare(void);
 #define PREPARE(argc, argv) prepare ()
 
-static int do_test (void);
+static int do_test(void);
 #define TEST_FUNCTION do_test ()
 
 #include "../test-skeleton.c"
 
-
-static void
-prepare (void)
+static void prepare(void)
 {
-  fd = mkstemp (fname);
-  if (fd == -1)
-    {
-      printf ("mkstemp failed: %m\n");
-      exit (1);
-    }
-  add_temp_file (fname);
-  if (ftruncate (fd, 1000) < 0)
-    {
-      printf ("ftruncate failed: %m\n");
-      exit (1);
-    }
+	fd = mkstemp(fname);
+	if (fd == -1) {
+		printf("mkstemp failed: %m\n");
+		exit(1);
+	}
+	add_temp_file(fname);
+	if (ftruncate(fd, 1000) < 0) {
+		printf("ftruncate failed: %m\n");
+		exit(1);
+	}
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  struct
-  {
-    pthread_mutex_t m;
-    pthread_cond_t c;
-    int var;
-  } *p = mmap (NULL, sizeof (*p), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
-  if (p == MAP_FAILED)
-    {
-      printf ("initial mmap failed: %m\n");
-      return 1;
-    }
-
-  pthread_mutexattr_t ma;
-  if (pthread_mutexattr_init (&ma) != 0)
-    {
-      puts ("mutexattr_init failed");
-      return 1;
-    }
-  if (pthread_mutexattr_setpshared (&ma, 1) != 0)
-    {
-      puts ("mutexattr_setpshared failed");
-      return 1;
-    }
-  if (pthread_mutex_init (&p->m, &ma) != 0)
-    {
-      puts ("mutex_init failed");
-      return 1;
-    }
-  if (pthread_mutexattr_destroy (&ma) != 0)
-    {
-      puts ("mutexattr_destroy failed");
-      return 1;
-    }
-
-  pthread_condattr_t ca;
-  if (pthread_condattr_init (&ca) != 0)
-    {
-      puts ("condattr_init failed");
-      return 1;
-    }
-  if (pthread_condattr_setpshared (&ca, 1) != 0)
-    {
-      puts ("condattr_setpshared failed");
-      return 1;
-    }
-  if (pthread_cond_init (&p->c, &ca) != 0)
-    {
-      puts ("mutex_init failed");
-      return 1;
-    }
-  if (pthread_condattr_destroy (&ca) != 0)
-    {
-      puts ("condattr_destroy failed");
-      return 1;
-    }
-
-  if (pthread_mutex_lock (&p->m) != 0)
-    {
-      puts ("initial mutex_lock failed");
-      return 1;
-    }
-
-  p->var = 42;
-
-  pid_t pid = fork ();
-  if (pid == -1)
-    {
-      printf ("fork failed: %m\n");
-      return 1;
-    }
-
-  if (pid == 0)
-    {
-      void *oldp = p;
-      p = mmap (NULL, sizeof (*p), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
-
-      if (p == oldp)
-	{
-	  puts ("child: mapped to same address");
-	  kill (getppid (), SIGKILL);
-	  exit (1);
+	struct {
+		pthread_mutex_t m;
+		pthread_cond_t c;
+		int var;
+	} *p =
+	    mmap(NULL, sizeof(*p), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (p == MAP_FAILED) {
+		printf("initial mmap failed: %m\n");
+		return 1;
 	}
 
-      munmap (oldp, sizeof (*p));
-
-      if (pthread_mutex_lock (&p->m) != 0)
-	{
-	  puts ("child: mutex_lock failed");
-	  kill (getppid (), SIGKILL);
-	  exit (1);
+	pthread_mutexattr_t ma;
+	if (pthread_mutexattr_init(&ma) != 0) {
+		puts("mutexattr_init failed");
+		return 1;
+	}
+	if (pthread_mutexattr_setpshared(&ma, 1) != 0) {
+		puts("mutexattr_setpshared failed");
+		return 1;
+	}
+	if (pthread_mutex_init(&p->m, &ma) != 0) {
+		puts("mutex_init failed");
+		return 1;
+	}
+	if (pthread_mutexattr_destroy(&ma) != 0) {
+		puts("mutexattr_destroy failed");
+		return 1;
 	}
 
-      p->var = 0;
+	pthread_condattr_t ca;
+	if (pthread_condattr_init(&ca) != 0) {
+		puts("condattr_init failed");
+		return 1;
+	}
+	if (pthread_condattr_setpshared(&ca, 1) != 0) {
+		puts("condattr_setpshared failed");
+		return 1;
+	}
+	if (pthread_cond_init(&p->c, &ca) != 0) {
+		puts("mutex_init failed");
+		return 1;
+	}
+	if (pthread_condattr_destroy(&ca) != 0) {
+		puts("condattr_destroy failed");
+		return 1;
+	}
+
+	if (pthread_mutex_lock(&p->m) != 0) {
+		puts("initial mutex_lock failed");
+		return 1;
+	}
+
+	p->var = 42;
+
+	pid_t pid = fork();
+	if (pid == -1) {
+		printf("fork failed: %m\n");
+		return 1;
+	}
+
+	if (pid == 0) {
+		void *oldp = p;
+		p = mmap(NULL, sizeof(*p), PROT_READ | PROT_WRITE, MAP_SHARED,
+			 fd, 0);
+
+		if (p == oldp) {
+			puts("child: mapped to same address");
+			kill(getppid(), SIGKILL);
+			exit(1);
+		}
+
+		munmap(oldp, sizeof(*p));
+
+		if (pthread_mutex_lock(&p->m) != 0) {
+			puts("child: mutex_lock failed");
+			kill(getppid(), SIGKILL);
+			exit(1);
+		}
+
+		p->var = 0;
 
 #ifndef USE_COND_SIGNAL
-      if (pthread_cond_broadcast (&p->c) != 0)
-	{
-	  puts ("child: cond_broadcast failed");
-	  kill (getppid (), SIGKILL);
-	  exit (1);
-	}
+		if (pthread_cond_broadcast(&p->c) != 0) {
+			puts("child: cond_broadcast failed");
+			kill(getppid(), SIGKILL);
+			exit(1);
+		}
 #else
-      if (pthread_cond_signal (&p->c) != 0)
-	{
-	  puts ("child: cond_signal failed");
-	  kill (getppid (), SIGKILL);
-	  exit (1);
-	}
+		if (pthread_cond_signal(&p->c) != 0) {
+			puts("child: cond_signal failed");
+			kill(getppid(), SIGKILL);
+			exit(1);
+		}
 #endif
 
-      if (pthread_mutex_unlock (&p->m) != 0)
-	{
-	  puts ("child: mutex_unlock failed");
-	  kill (getppid (), SIGKILL);
-	  exit (1);
+		if (pthread_mutex_unlock(&p->m) != 0) {
+			puts("child: mutex_unlock failed");
+			kill(getppid(), SIGKILL);
+			exit(1);
+		}
+
+		exit(0);
 	}
 
-      exit (0);
-    }
+	do
+		pthread_cond_wait(&p->c, &p->m);
+	while (p->var != 0);
 
-  do
-    pthread_cond_wait (&p->c, &p->m);
-  while (p->var != 0);
+	if (TEMP_FAILURE_RETRY(waitpid(pid, NULL, 0)) != pid) {
+		printf("waitpid failed: %m\n");
+		kill(pid, SIGKILL);
+		return 1;
+	}
 
-  if (TEMP_FAILURE_RETRY (waitpid (pid, NULL, 0)) != pid)
-    {
-      printf ("waitpid failed: %m\n");
-      kill (pid, SIGKILL);
-      return 1;
-    }
-
-  return 0;
+	return 0;
 }

--- a/tests/glibc-tests/tst-cond13.c
+++ b/tests/glibc-tests/tst-cond13.c
@@ -1,0 +1,2 @@
+#define USE_COND_SIGNAL 1
+#include "tst-cond12.c"

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -1,0 +1,106 @@
+/* Copyright (C) 2004-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Jakub Jelinek <jakub@redhat.com>, 2004.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+pthread_cond_t cv = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+bool n, exiting;
+FILE *f;
+enum { count = 8 };		/* Number of worker threads.  */
+
+void *
+tf (void *dummy)
+{
+  bool loop = true;
+
+  while (loop)
+    {
+      pthread_mutex_lock (&lock);
+      while (n && !exiting)
+	pthread_cond_wait (&cv, &lock);
+      n = true;
+      pthread_mutex_unlock (&lock);
+
+      fputs (".", f);
+
+      pthread_mutex_lock (&lock);
+      n = false;
+      if (exiting)
+	loop = false;
+#ifdef UNLOCK_AFTER_BROADCAST
+      pthread_cond_broadcast (&cv);
+      pthread_mutex_unlock (&lock);
+#else
+      pthread_mutex_unlock (&lock);
+      pthread_cond_broadcast (&cv);
+#endif
+    }
+
+  return NULL;
+}
+
+int
+do_test (void)
+{
+  f = fopen ("/dev/null", "w");
+  if (f == NULL)
+    {
+      printf ("couldn't open /dev/null, %m\n");
+      return 1;
+    }
+
+  pthread_t th[count];
+  pthread_attr_t attr;
+  int i, ret, sz;
+  pthread_attr_init (&attr);
+  sz = sysconf (_SC_PAGESIZE);
+  if (sz < PTHREAD_STACK_MIN)
+	  sz = PTHREAD_STACK_MIN;
+  pthread_attr_setstacksize (&attr, sz);
+  for (i = 0; i < count; ++i)
+    if ((ret = pthread_create (&th[i], &attr, tf, NULL)) != 0)
+      {
+	errno = ret;
+	printf ("pthread_create %d failed: %m\n", i);
+	return 1;
+      }
+
+  struct timespec ts = { .tv_sec = 20, .tv_nsec = 0 };
+  while (nanosleep (&ts, &ts) != 0);
+
+  pthread_mutex_lock (&lock);
+  exiting = true;
+  pthread_mutex_unlock (&lock);
+
+  for (i = 0; i < count; ++i)
+    pthread_join (th[i], NULL);
+
+  fclose (f);
+  return 0;
+}
+
+#define TEST_FUNCTION do_test ()
+#define TIMEOUT 40
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -96,6 +96,5 @@ int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
 #define TIMEOUT 40
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond17.c
+++ b/tests/glibc-tests/tst-cond17.c
@@ -1,0 +1,2 @@
+#define UNLOCK_AFTER_BROADCAST 1
+#include "tst-cond16.c"

--- a/tests/glibc-tests/tst-cond18.c
+++ b/tests/glibc-tests/tst-cond18.c
@@ -1,0 +1,119 @@
+/* Copyright (C) 2004-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Jakub Jelinek <jakub@redhat.com>, 2004.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+pthread_cond_t cv = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+bool exiting;
+int fd, spins, nn;
+enum { count = 8 };		/* Number of worker threads.  */
+
+void *
+tf (void *id)
+{
+  pthread_mutex_lock (&lock);
+
+  if ((long) id == 0)
+    {
+      while (!exiting)
+	{
+	  if ((spins++ % 1000) == 0)
+	    write (fd, ".", 1);
+	  pthread_mutex_unlock (&lock);
+
+	  pthread_mutex_lock (&lock);
+	  int njobs = rand () % (count + 1);
+	  nn = njobs;
+	  if ((rand () % 30) == 0)
+	    pthread_cond_broadcast (&cv);
+	  else
+	    while (njobs--)
+	      pthread_cond_signal (&cv);
+	}
+
+      pthread_cond_broadcast (&cv);
+    }
+  else
+    {
+      while (!exiting)
+	{
+	  while (!nn && !exiting)
+	    pthread_cond_wait (&cv, &lock);
+	  --nn;
+	  pthread_mutex_unlock (&lock);
+
+	  pthread_mutex_lock (&lock);
+	}
+    }
+
+  pthread_mutex_unlock (&lock);
+  return NULL;
+}
+
+int
+do_test (void)
+{
+  fd = open ("/dev/null", O_WRONLY);
+  if (fd < 0)
+    {
+      printf ("couldn't open /dev/null, %m\n");
+      return 1;
+    }
+
+  pthread_t th[count + 1];
+  pthread_attr_t attr;
+  int i, ret, sz;
+  pthread_attr_init (&attr);
+  sz = sysconf (_SC_PAGESIZE);
+  if (sz < PTHREAD_STACK_MIN)
+	  sz = PTHREAD_STACK_MIN;
+  pthread_attr_setstacksize (&attr, sz);
+
+  for (i = 0; i <= count; ++i)
+    if ((ret = pthread_create (&th[i], &attr, tf, (void *) (long) i)) != 0)
+      {
+	errno = ret;
+	printf ("pthread_create %d failed: %m\n", i);
+	return 1;
+      }
+
+  struct timespec ts = { .tv_sec = 20, .tv_nsec = 0 };
+  while (nanosleep (&ts, &ts) != 0);
+
+  pthread_mutex_lock (&lock);
+  exiting = true;
+  pthread_mutex_unlock (&lock);
+
+  for (i = 0; i < count; ++i)
+    pthread_join (th[i], NULL);
+
+  close (fd);
+  return 0;
+}
+
+#define TEST_FUNCTION do_test ()
+#define TIMEOUT 40
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond18.c
+++ b/tests/glibc-tests/tst-cond18.c
@@ -106,6 +106,5 @@ int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
 #define TIMEOUT 40
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -1,0 +1,75 @@
+/* Copyright (C) 2004-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2004.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+
+
+static int
+do_test (void)
+{
+  int result = 0;
+  struct timespec ts;
+
+  if (clock_gettime (CLOCK_REALTIME, &ts) != 0)
+    {
+      puts ("clock_gettime failed");
+      return 1;
+    }
+
+  ts.tv_nsec = -1;
+
+  int e = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (e == 0)
+    {
+      puts ("first cond_timedwait did not fail");
+      result = 1;
+    }
+  else if (e != EINVAL)
+    {
+      puts ("first cond_timedwait did not return EINVAL");
+      result = 1;
+    }
+
+  ts.tv_nsec = 2000000000;
+
+  e = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (e == 0)
+    {
+      puts ("second cond_timedwait did not fail");
+      result = 1;
+    }
+  else if (e != EINVAL)
+    {
+      puts ("second cond_timedwait did not return EINVAL");
+      result = 1;
+    }
+
+  return result;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -60,5 +60,4 @@ static int do_test(void)
 	return result;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -22,54 +22,43 @@
 #include <stdlib.h>
 #include <time.h>
 
-
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  int result = 0;
-  struct timespec ts;
+	int result = 0;
+	struct timespec ts;
 
-  if (clock_gettime (CLOCK_REALTIME, &ts) != 0)
-    {
-      puts ("clock_gettime failed");
-      return 1;
-    }
+	if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+		puts("clock_gettime failed");
+		return 1;
+	}
 
-  ts.tv_nsec = -1;
+	ts.tv_nsec = -1;
 
-  int e = pthread_cond_timedwait (&cond, &mut, &ts);
-  if (e == 0)
-    {
-      puts ("first cond_timedwait did not fail");
-      result = 1;
-    }
-  else if (e != EINVAL)
-    {
-      puts ("first cond_timedwait did not return EINVAL");
-      result = 1;
-    }
+	int e = pthread_cond_timedwait(&cond, &mut, &ts);
+	if (e == 0) {
+		puts("first cond_timedwait did not fail");
+		result = 1;
+	} else if (e != EINVAL) {
+		puts("first cond_timedwait did not return EINVAL");
+		result = 1;
+	}
 
-  ts.tv_nsec = 2000000000;
+	ts.tv_nsec = 2000000000;
 
-  e = pthread_cond_timedwait (&cond, &mut, &ts);
-  if (e == 0)
-    {
-      puts ("second cond_timedwait did not fail");
-      result = 1;
-    }
-  else if (e != EINVAL)
-    {
-      puts ("second cond_timedwait did not return EINVAL");
-      result = 1;
-    }
+	e = pthread_cond_timedwait(&cond, &mut, &ts);
+	if (e == 0) {
+		puts("second cond_timedwait did not fail");
+		result = 1;
+	} else if (e != EINVAL) {
+		puts("second cond_timedwait did not return EINVAL");
+		result = 1;
+	}
 
-  return result;
+	return result;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -1,0 +1,162 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <error.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+static pthread_barrier_t bar;
+
+
+static void *
+tf (void *a)
+{
+  int i = (long int) a;
+  int err;
+
+  printf ("child %d: lock\n", i);
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "locking in child failed");
+
+  printf ("child %d: sync\n", i);
+
+  int e = pthread_barrier_wait (&bar);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("child: barrier_wait failed");
+      exit (1);
+    }
+
+  printf ("child %d: wait\n", i);
+
+  err = pthread_cond_wait (&cond, &mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "child %d: failed to wait", i);
+
+  printf ("child %d: woken up\n", i);
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "child %d: unlock[2] failed", i);
+
+  printf ("child %d: done\n", i);
+
+  return NULL;
+}
+
+
+#define N 10
+
+
+static int
+do_test (void)
+{
+  pthread_t th[N];
+  int i;
+  int err;
+
+  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+
+  if (pthread_barrier_init (&bar, NULL, 2) != 0)
+    {
+      puts ("barrier_init failed");
+      exit (1);
+    }
+
+  pthread_attr_t at;
+
+  if (pthread_attr_init (&at) != 0)
+    {
+      puts ("attr_init failed");
+      return 1;
+    }
+
+  if (pthread_attr_setstacksize (&at, 1 * 1024 * 1024) != 0)
+    {
+      puts ("attr_setstacksize failed");
+      return 1;
+    }
+
+  for (i = 0; i < N; ++i)
+    {
+      printf ("create thread %d\n", i);
+
+      err = pthread_create (&th[i], &at, tf, (void *) (long int) i);
+      if (err != 0)
+	error (EXIT_FAILURE, err, "cannot create thread %d", i);
+
+      printf ("wait for child %d\n", i);
+
+      /* Wait for the child to start up and get the mutex for the
+	 conditional variable.  */
+      int e = pthread_barrier_wait (&bar);
+      if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("barrier_wait failed");
+	  exit (1);
+	}
+    }
+
+  if (pthread_attr_destroy (&at) != 0)
+    {
+      puts ("attr_destroy failed");
+      return 1;
+    }
+
+  puts ("get lock outselves");
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "mut locking failed");
+
+  puts ("broadcast");
+
+  /* Wake up all threads.  */
+  err = pthread_cond_broadcast (&cond);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: broadcast failed");
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "mut unlocking failed");
+
+  /* Join all threads.  */
+  for (i = 0; i < N; ++i)
+    {
+      printf ("join thread %d\n", i);
+
+      err = pthread_join (th[i], NULL);
+      if (err != 0)
+	error (EXIT_FAILURE, err, "join of child %d failed", i);
+    }
+
+  puts ("done");
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -21,142 +21,127 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 
 static pthread_barrier_t bar;
 
-
-static void *
-tf (void *a)
+static void *tf(void *a)
 {
-  int i = (long int) a;
-  int err;
+	int i = (long int)a;
+	int err;
 
-  printf ("child %d: lock\n", i);
+	printf("child %d: lock\n", i);
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "locking in child failed");
+	err = pthread_mutex_lock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "locking in child failed");
 
-  printf ("child %d: sync\n", i);
+	printf("child %d: sync\n", i);
 
-  int e = pthread_barrier_wait (&bar);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("child: barrier_wait failed");
-      exit (1);
-    }
+	int e = pthread_barrier_wait(&bar);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("child: barrier_wait failed");
+		exit(1);
+	}
 
-  printf ("child %d: wait\n", i);
+	printf("child %d: wait\n", i);
 
-  err = pthread_cond_wait (&cond, &mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "child %d: failed to wait", i);
+	err = pthread_cond_wait(&cond, &mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "child %d: failed to wait", i);
 
-  printf ("child %d: woken up\n", i);
+	printf("child %d: woken up\n", i);
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "child %d: unlock[2] failed", i);
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "child %d: unlock[2] failed", i);
 
-  printf ("child %d: done\n", i);
+	printf("child %d: done\n", i);
 
-  return NULL;
+	return NULL;
 }
-
 
 #define N 10
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  pthread_t th[N];
-  int i;
-  int err;
+	pthread_t th[N];
+	int i;
+	int err;
 
-  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+	printf("&cond = %p\n&mut = %p\n", &cond, &mut);
 
-  if (pthread_barrier_init (&bar, NULL, 2) != 0)
-    {
-      puts ("barrier_init failed");
-      exit (1);
-    }
-
-  pthread_attr_t at;
-
-  if (pthread_attr_init (&at) != 0)
-    {
-      puts ("attr_init failed");
-      return 1;
-    }
-
-  if (pthread_attr_setstacksize (&at, 1 * 1024 * 1024) != 0)
-    {
-      puts ("attr_setstacksize failed");
-      return 1;
-    }
-
-  for (i = 0; i < N; ++i)
-    {
-      printf ("create thread %d\n", i);
-
-      err = pthread_create (&th[i], &at, tf, (void *) (long int) i);
-      if (err != 0)
-	error (EXIT_FAILURE, err, "cannot create thread %d", i);
-
-      printf ("wait for child %d\n", i);
-
-      /* Wait for the child to start up and get the mutex for the
-	 conditional variable.  */
-      int e = pthread_barrier_wait (&bar);
-      if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("barrier_wait failed");
-	  exit (1);
+	if (pthread_barrier_init(&bar, NULL, 2) != 0) {
+		puts("barrier_init failed");
+		exit(1);
 	}
-    }
 
-  if (pthread_attr_destroy (&at) != 0)
-    {
-      puts ("attr_destroy failed");
-      return 1;
-    }
+	pthread_attr_t at;
 
-  puts ("get lock outselves");
+	if (pthread_attr_init(&at) != 0) {
+		puts("attr_init failed");
+		return 1;
+	}
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "mut locking failed");
+	if (pthread_attr_setstacksize(&at, 1 * 1024 * 1024) != 0) {
+		puts("attr_setstacksize failed");
+		return 1;
+	}
 
-  puts ("broadcast");
+	for (i = 0; i < N; ++i) {
+		printf("create thread %d\n", i);
 
-  /* Wake up all threads.  */
-  err = pthread_cond_broadcast (&cond);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "parent: broadcast failed");
+		err = pthread_create(&th[i], &at, tf, (void *)(long int)i);
+		if (err != 0)
+			error(EXIT_FAILURE, err, "cannot create thread %d", i);
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    error (EXIT_FAILURE, err, "mut unlocking failed");
+		printf("wait for child %d\n", i);
 
-  /* Join all threads.  */
-  for (i = 0; i < N; ++i)
-    {
-      printf ("join thread %d\n", i);
+		/* Wait for the child to start up and get the mutex for the
+		   conditional variable.  */
+		int e = pthread_barrier_wait(&bar);
+		if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("barrier_wait failed");
+			exit(1);
+		}
+	}
 
-      err = pthread_join (th[i], NULL);
-      if (err != 0)
-	error (EXIT_FAILURE, err, "join of child %d failed", i);
-    }
+	if (pthread_attr_destroy(&at) != 0) {
+		puts("attr_destroy failed");
+		return 1;
+	}
 
-  puts ("done");
+	puts("get lock outselves");
 
-  return 0;
+	err = pthread_mutex_lock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "mut locking failed");
+
+	puts("broadcast");
+
+	/* Wake up all threads.  */
+	err = pthread_cond_broadcast(&cond);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "parent: broadcast failed");
+
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0)
+		error(EXIT_FAILURE, err, "mut unlocking failed");
+
+	/* Join all threads.  */
+	for (i = 0; i < N; ++i) {
+		printf("join thread %d\n", i);
+
+		err = pthread_join(th[i], NULL);
+		if (err != 0)
+			error(EXIT_FAILURE, err, "join of child %d failed", i);
+	}
+
+	puts("done");
+
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -143,5 +143,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond20.c
+++ b/tests/glibc-tests/tst-cond20.c
@@ -1,0 +1,172 @@
+/* Copyright (C) 2004-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Jakub Jelinek <jakub@redhat.com>, 2004.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define N 10
+#define ROUNDS 1000
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t cond2 = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pthread_barrier_t b;
+static int count;
+
+static void *
+tf (void *p)
+{
+  int i;
+  for (i = 0; i < ROUNDS; ++i)
+    {
+      pthread_mutex_lock (&mut);
+
+      if (++count == N)
+	pthread_cond_signal (&cond2);
+
+#ifdef TIMED
+      struct timeval tv;
+      gettimeofday (&tv, NULL);
+      struct timespec ts;
+      /* Wait three seconds.  */
+      ts.tv_sec = tv.tv_sec + 3;
+      ts.tv_nsec = tv.tv_usec * 1000;
+      pthread_cond_timedwait (&cond, &mut, &ts);
+#else
+      pthread_cond_wait (&cond, &mut);
+#endif
+
+      pthread_mutex_unlock (&mut);
+
+      int err = pthread_barrier_wait (&b);
+      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("child: barrier_wait failed");
+	  exit (1);
+	}
+
+      err = pthread_barrier_wait (&b);
+      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("child: barrier_wait failed");
+	  exit (1);
+	}
+    }
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  if (pthread_barrier_init (&b, NULL, N + 1) != 0)
+    {
+      puts ("barrier_init failed");
+      return 1;
+    }
+
+  pthread_mutex_lock (&mut);
+
+  int i, j, err;
+  pthread_t th[N];
+  for (i = 0; i < N; ++i)
+    if ((err = pthread_create (&th[i], NULL, tf, NULL)) != 0)
+      {
+	printf ("cannot create thread %d: %s\n", i, strerror (err));
+	return 1;
+      }
+
+  for (i = 0; i < ROUNDS; ++i)
+    {
+      /* Make sure we discard spurious wake-ups.  */
+      do
+	pthread_cond_wait (&cond2, &mut);
+      while (count != N);
+
+      if (i & 1)
+        pthread_mutex_unlock (&mut);
+
+      if (i & 2)
+	pthread_cond_broadcast (&cond);
+      else if (i & 4)
+	for (j = 0; j < N; ++j)
+	  pthread_cond_signal (&cond);
+      else
+	{
+	  for (j = 0; j < (i / 8) % N; ++j)
+	    pthread_cond_signal (&cond);
+	  pthread_cond_broadcast (&cond);
+	}
+
+      if ((i & 1) == 0)
+        pthread_mutex_unlock (&mut);
+
+      err = pthread_cond_destroy (&cond);
+      if (err)
+	{
+	  printf ("pthread_cond_destroy failed: %s\n", strerror (err));
+	  return 1;
+	}
+
+      /* Now clobber the cond variable which has been successfully
+         destroyed above.  */
+      memset (&cond, (char) i, sizeof (cond));
+
+      err = pthread_barrier_wait (&b);
+      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("parent: barrier_wait failed");
+	  return 1;
+	}
+
+      pthread_mutex_lock (&mut);
+
+      err = pthread_barrier_wait (&b);
+      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+	{
+	  puts ("parent: barrier_wait failed");
+	  return 1;
+	}
+
+      count = 0;
+      err = pthread_cond_init (&cond, NULL);
+      if (err)
+	{
+	  printf ("pthread_cond_init failed: %s\n", strerror (err));
+	  return 1;
+	}
+    }
+
+  for (i = 0; i < N; ++i)
+    if ((err = pthread_join (th[i], NULL)) != 0)
+      {
+	printf ("failed to join thread %d: %s\n", i, strerror (err));
+	return 1;
+      }
+
+  puts ("done");
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond20.c
+++ b/tests/glibc-tests/tst-cond20.c
@@ -30,143 +30,130 @@ static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 static pthread_barrier_t b;
 static int count;
 
-static void *
-tf (void *p)
+static void *tf(void *p)
 {
-  int i;
-  for (i = 0; i < ROUNDS; ++i)
-    {
-      pthread_mutex_lock (&mut);
+	int i;
+	for (i = 0; i < ROUNDS; ++i) {
+		pthread_mutex_lock(&mut);
 
-      if (++count == N)
-	pthread_cond_signal (&cond2);
+		if (++count == N)
+			pthread_cond_signal(&cond2);
 
 #ifdef TIMED
-      struct timeval tv;
-      gettimeofday (&tv, NULL);
-      struct timespec ts;
-      /* Wait three seconds.  */
-      ts.tv_sec = tv.tv_sec + 3;
-      ts.tv_nsec = tv.tv_usec * 1000;
-      pthread_cond_timedwait (&cond, &mut, &ts);
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+		struct timespec ts;
+		/* Wait three seconds.  */
+		ts.tv_sec = tv.tv_sec + 3;
+		ts.tv_nsec = tv.tv_usec * 1000;
+		pthread_cond_timedwait(&cond, &mut, &ts);
 #else
-      pthread_cond_wait (&cond, &mut);
+		pthread_cond_wait(&cond, &mut);
 #endif
 
-      pthread_mutex_unlock (&mut);
+		pthread_mutex_unlock(&mut);
 
-      int err = pthread_barrier_wait (&b);
-      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("child: barrier_wait failed");
-	  exit (1);
+		int err = pthread_barrier_wait(&b);
+		if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("child: barrier_wait failed");
+			exit(1);
+		}
+
+		err = pthread_barrier_wait(&b);
+		if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("child: barrier_wait failed");
+			exit(1);
+		}
 	}
 
-      err = pthread_barrier_wait (&b);
-      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("child: barrier_wait failed");
-	  exit (1);
-	}
-    }
-
-  return NULL;
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  if (pthread_barrier_init (&b, NULL, N + 1) != 0)
-    {
-      puts ("barrier_init failed");
-      return 1;
-    }
-
-  pthread_mutex_lock (&mut);
-
-  int i, j, err;
-  pthread_t th[N];
-  for (i = 0; i < N; ++i)
-    if ((err = pthread_create (&th[i], NULL, tf, NULL)) != 0)
-      {
-	printf ("cannot create thread %d: %s\n", i, strerror (err));
-	return 1;
-      }
-
-  for (i = 0; i < ROUNDS; ++i)
-    {
-      /* Make sure we discard spurious wake-ups.  */
-      do
-	pthread_cond_wait (&cond2, &mut);
-      while (count != N);
-
-      if (i & 1)
-        pthread_mutex_unlock (&mut);
-
-      if (i & 2)
-	pthread_cond_broadcast (&cond);
-      else if (i & 4)
-	for (j = 0; j < N; ++j)
-	  pthread_cond_signal (&cond);
-      else
-	{
-	  for (j = 0; j < (i / 8) % N; ++j)
-	    pthread_cond_signal (&cond);
-	  pthread_cond_broadcast (&cond);
+	if (pthread_barrier_init(&b, NULL, N + 1) != 0) {
+		puts("barrier_init failed");
+		return 1;
 	}
 
-      if ((i & 1) == 0)
-        pthread_mutex_unlock (&mut);
+	pthread_mutex_lock(&mut);
 
-      err = pthread_cond_destroy (&cond);
-      if (err)
-	{
-	  printf ("pthread_cond_destroy failed: %s\n", strerror (err));
-	  return 1;
+	int i, j, err;
+	pthread_t th[N];
+	for (i = 0; i < N; ++i)
+		if ((err = pthread_create(&th[i], NULL, tf, NULL)) != 0) {
+			printf("cannot create thread %d: %s\n", i,
+			       strerror(err));
+			return 1;
+		}
+
+	for (i = 0; i < ROUNDS; ++i) {
+		/* Make sure we discard spurious wake-ups.  */
+		do
+			pthread_cond_wait(&cond2, &mut);
+		while (count != N);
+
+		if (i & 1)
+			pthread_mutex_unlock(&mut);
+
+		if (i & 2)
+			pthread_cond_broadcast(&cond);
+		else if (i & 4)
+			for (j = 0; j < N; ++j)
+				pthread_cond_signal(&cond);
+		else {
+			for (j = 0; j < (i / 8) % N; ++j)
+				pthread_cond_signal(&cond);
+			pthread_cond_broadcast(&cond);
+		}
+
+		if ((i & 1) == 0)
+			pthread_mutex_unlock(&mut);
+
+		err = pthread_cond_destroy(&cond);
+		if (err) {
+			printf("pthread_cond_destroy failed: %s\n",
+			       strerror(err));
+			return 1;
+		}
+
+		/* Now clobber the cond variable which has been successfully
+		   destroyed above.  */
+		memset(&cond, (char)i, sizeof(cond));
+
+		err = pthread_barrier_wait(&b);
+		if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("parent: barrier_wait failed");
+			return 1;
+		}
+
+		pthread_mutex_lock(&mut);
+
+		err = pthread_barrier_wait(&b);
+		if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+			puts("parent: barrier_wait failed");
+			return 1;
+		}
+
+		count = 0;
+		err = pthread_cond_init(&cond, NULL);
+		if (err) {
+			printf("pthread_cond_init failed: %s\n", strerror(err));
+			return 1;
+		}
 	}
 
-      /* Now clobber the cond variable which has been successfully
-         destroyed above.  */
-      memset (&cond, (char) i, sizeof (cond));
+	for (i = 0; i < N; ++i)
+		if ((err = pthread_join(th[i], NULL)) != 0) {
+			printf("failed to join thread %d: %s\n", i,
+			       strerror(err));
+			return 1;
+		}
 
-      err = pthread_barrier_wait (&b);
-      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("parent: barrier_wait failed");
-	  return 1;
-	}
+	puts("done");
 
-      pthread_mutex_lock (&mut);
-
-      err = pthread_barrier_wait (&b);
-      if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-	{
-	  puts ("parent: barrier_wait failed");
-	  return 1;
-	}
-
-      count = 0;
-      err = pthread_cond_init (&cond, NULL);
-      if (err)
-	{
-	  printf ("pthread_cond_init failed: %s\n", strerror (err));
-	  return 1;
-	}
-    }
-
-  for (i = 0; i < N; ++i)
-    if ((err = pthread_join (th[i], NULL)) != 0)
-      {
-	printf ("failed to join thread %d: %s\n", i, strerror (err));
-	return 1;
-      }
-
-  puts ("done");
-
-  return 0;
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond20.c
+++ b/tests/glibc-tests/tst-cond20.c
@@ -155,5 +155,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond21.c
+++ b/tests/glibc-tests/tst-cond21.c
@@ -1,0 +1,3 @@
+#include <sys/time.h>
+#define TIMED 1
+#include "tst-cond20.c"

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -1,0 +1,162 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+static pthread_barrier_t b;
+static pthread_cond_t c = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+
+static void
+cl (void *arg)
+{
+  pthread_mutex_unlock (&m);
+}
+
+
+static void *
+tf (void *arg)
+{
+  if (pthread_mutex_lock (&m) != 0)
+    {
+      printf ("%s: mutex_lock failed\n", __func__);
+      exit (1);
+    }
+  int e = pthread_barrier_wait (&b);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      printf ("%s: barrier_wait failed\n", __func__);
+      exit (1);
+    }
+  pthread_cleanup_push (cl, NULL);
+  /* We have to loop here because the cancellation might come after
+     the cond_wait call left the cancelable area and is then waiting
+     on the mutex.  In this case the beginning of the second cond_wait
+     call will cause the cancellation to happen.  */
+  do
+    if (pthread_cond_wait (&c, &m) != 0)
+      {
+	printf ("%s: cond_wait failed\n", __func__);
+	exit (1);
+      }
+  while (arg == NULL);
+  pthread_cleanup_pop (0);
+  if (pthread_mutex_unlock (&m) != 0)
+    {
+      printf ("%s: mutex_unlock failed\n", __func__);
+      exit (1);
+    }
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  int status = 0;
+
+  if (pthread_barrier_init (&b, NULL, 2) != 0)
+    {
+      puts ("barrier_init failed");
+      return 1;
+    }
+
+  pthread_t th;
+  if (pthread_create (&th, NULL, tf, NULL) != 0)
+    {
+      puts ("1st create failed");
+      return 1;
+    }
+  int e = pthread_barrier_wait (&b);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("1st barrier_wait failed");
+      return 1;
+    }
+  if (pthread_mutex_lock (&m) != 0)
+    {
+      puts ("1st mutex_lock failed");
+      return 1;
+    }
+  if (pthread_cond_signal (&c) != 0)
+    {
+      puts ("1st cond_signal failed");
+      return 1;
+    }
+  if (pthread_cancel (th) != 0)
+    {
+      puts ("cancel failed");
+      return 1;
+    }
+  if (pthread_mutex_unlock (&m) != 0)
+    {
+      puts ("1st mutex_unlock failed");
+      return 1;
+    }
+  void *res;
+  if (pthread_join (th, &res) != 0)
+    {
+      puts ("1st join failed");
+      return 1;
+    }
+  if (res != PTHREAD_CANCELED)
+    {
+      puts ("first thread not canceled");
+      status = 1;
+    }
+
+  printf ("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
+	  c.__data.__wseq, c.__data.__g1_start,
+	  c.__data.__g_signals[0], c.__data.__g_refs[0], c.__data.__g_size[0],
+	  c.__data.__g_signals[1], c.__data.__g_refs[1], c.__data.__g_size[1],
+	  c.__data.__g1_orig_size, c.__data.__wrefs);
+
+  if (pthread_create (&th, NULL, tf, (void *) 1l) != 0)
+    {
+      puts ("2nd create failed");
+      return 1;
+    }
+  e = pthread_barrier_wait (&b);
+  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("2nd barrier_wait failed");
+      return 1;
+    }
+  if (pthread_mutex_lock (&m) != 0)
+    {
+      puts ("2nd mutex_lock failed");
+      return 1;
+    }
+  if (pthread_cond_signal (&c) != 0)
+    {
+      puts ("2nd cond_signal failed");
+      return 1;
+    }
+  if (pthread_mutex_unlock (&m) != 0)
+    {
+      puts ("2nd mutex_unlock failed");
+      return 1;
+    }
+  if (pthread_join (th, &res) != 0)
+    {
+      puts ("2nd join failed");
+      return 1;
+    }
+  if (res != NULL)
+    {
+      puts ("2nd thread canceled");
+      status = 1;
+    }
+
+  printf ("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
+	  c.__data.__wseq, c.__data.__g1_start,
+	  c.__data.__g_signals[0], c.__data.__g_refs[0], c.__data.__g_size[0],
+	  c.__data.__g_signals[1], c.__data.__g_refs[1], c.__data.__g_size[1],
+	  c.__data.__g1_orig_size, c.__data.__wrefs);
+
+  return status;
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -133,5 +133,4 @@ static int do_test(void)
 	return status;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -2,160 +2,135 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
 static pthread_barrier_t b;
 static pthread_cond_t c = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
-
-static void
-cl (void *arg)
+static void cl(void *arg)
 {
-  pthread_mutex_unlock (&m);
+	pthread_mutex_unlock(&m);
 }
 
-
-static void *
-tf (void *arg)
+static void *tf(void *arg)
 {
-  if (pthread_mutex_lock (&m) != 0)
-    {
-      printf ("%s: mutex_lock failed\n", __func__);
-      exit (1);
-    }
-  int e = pthread_barrier_wait (&b);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      printf ("%s: barrier_wait failed\n", __func__);
-      exit (1);
-    }
-  pthread_cleanup_push (cl, NULL);
-  /* We have to loop here because the cancellation might come after
-     the cond_wait call left the cancelable area and is then waiting
-     on the mutex.  In this case the beginning of the second cond_wait
-     call will cause the cancellation to happen.  */
-  do
-    if (pthread_cond_wait (&c, &m) != 0)
-      {
-	printf ("%s: cond_wait failed\n", __func__);
-	exit (1);
-      }
-  while (arg == NULL);
-  pthread_cleanup_pop (0);
-  if (pthread_mutex_unlock (&m) != 0)
-    {
-      printf ("%s: mutex_unlock failed\n", __func__);
-      exit (1);
-    }
-  return NULL;
+	if (pthread_mutex_lock(&m) != 0) {
+		printf("%s: mutex_lock failed\n", __func__);
+		exit(1);
+	}
+	int e = pthread_barrier_wait(&b);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		printf("%s: barrier_wait failed\n", __func__);
+		exit(1);
+	}
+	pthread_cleanup_push(cl, NULL);
+	/* We have to loop here because the cancellation might come after
+	   the cond_wait call left the cancelable area and is then waiting
+	   on the mutex.  In this case the beginning of the second cond_wait
+	   call will cause the cancellation to happen.  */
+	do
+		if (pthread_cond_wait(&c, &m) != 0) {
+			printf("%s: cond_wait failed\n", __func__);
+			exit(1);
+		}
+	while (arg == NULL) ;
+	pthread_cleanup_pop(0);
+	if (pthread_mutex_unlock(&m) != 0) {
+		printf("%s: mutex_unlock failed\n", __func__);
+		exit(1);
+	}
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  int status = 0;
+	int status = 0;
 
-  if (pthread_barrier_init (&b, NULL, 2) != 0)
-    {
-      puts ("barrier_init failed");
-      return 1;
-    }
+	if (pthread_barrier_init(&b, NULL, 2) != 0) {
+		puts("barrier_init failed");
+		return 1;
+	}
 
-  pthread_t th;
-  if (pthread_create (&th, NULL, tf, NULL) != 0)
-    {
-      puts ("1st create failed");
-      return 1;
-    }
-  int e = pthread_barrier_wait (&b);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("1st barrier_wait failed");
-      return 1;
-    }
-  if (pthread_mutex_lock (&m) != 0)
-    {
-      puts ("1st mutex_lock failed");
-      return 1;
-    }
-  if (pthread_cond_signal (&c) != 0)
-    {
-      puts ("1st cond_signal failed");
-      return 1;
-    }
-  if (pthread_cancel (th) != 0)
-    {
-      puts ("cancel failed");
-      return 1;
-    }
-  if (pthread_mutex_unlock (&m) != 0)
-    {
-      puts ("1st mutex_unlock failed");
-      return 1;
-    }
-  void *res;
-  if (pthread_join (th, &res) != 0)
-    {
-      puts ("1st join failed");
-      return 1;
-    }
-  if (res != PTHREAD_CANCELED)
-    {
-      puts ("first thread not canceled");
-      status = 1;
-    }
+	pthread_t th;
+	if (pthread_create(&th, NULL, tf, NULL) != 0) {
+		puts("1st create failed");
+		return 1;
+	}
+	int e = pthread_barrier_wait(&b);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("1st barrier_wait failed");
+		return 1;
+	}
+	if (pthread_mutex_lock(&m) != 0) {
+		puts("1st mutex_lock failed");
+		return 1;
+	}
+	if (pthread_cond_signal(&c) != 0) {
+		puts("1st cond_signal failed");
+		return 1;
+	}
+	if (pthread_cancel(th) != 0) {
+		puts("cancel failed");
+		return 1;
+	}
+	if (pthread_mutex_unlock(&m) != 0) {
+		puts("1st mutex_unlock failed");
+		return 1;
+	}
+	void *res;
+	if (pthread_join(th, &res) != 0) {
+		puts("1st join failed");
+		return 1;
+	}
+	if (res != PTHREAD_CANCELED) {
+		puts("first thread not canceled");
+		status = 1;
+	}
 
-  printf ("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
-	  c.__data.__wseq, c.__data.__g1_start,
-	  c.__data.__g_signals[0], c.__data.__g_refs[0], c.__data.__g_size[0],
-	  c.__data.__g_signals[1], c.__data.__g_refs[1], c.__data.__g_size[1],
-	  c.__data.__g1_orig_size, c.__data.__wrefs);
+	printf("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
+	       c.__data.__wseq, c.__data.__g1_start,
+	       c.__data.__g_signals[0], c.__data.__g_refs[0],
+	       c.__data.__g_size[0], c.__data.__g_signals[1],
+	       c.__data.__g_refs[1], c.__data.__g_size[1],
+	       c.__data.__g1_orig_size, c.__data.__wrefs);
 
-  if (pthread_create (&th, NULL, tf, (void *) 1l) != 0)
-    {
-      puts ("2nd create failed");
-      return 1;
-    }
-  e = pthread_barrier_wait (&b);
-  if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("2nd barrier_wait failed");
-      return 1;
-    }
-  if (pthread_mutex_lock (&m) != 0)
-    {
-      puts ("2nd mutex_lock failed");
-      return 1;
-    }
-  if (pthread_cond_signal (&c) != 0)
-    {
-      puts ("2nd cond_signal failed");
-      return 1;
-    }
-  if (pthread_mutex_unlock (&m) != 0)
-    {
-      puts ("2nd mutex_unlock failed");
-      return 1;
-    }
-  if (pthread_join (th, &res) != 0)
-    {
-      puts ("2nd join failed");
-      return 1;
-    }
-  if (res != NULL)
-    {
-      puts ("2nd thread canceled");
-      status = 1;
-    }
+	if (pthread_create(&th, NULL, tf, (void *)1l) != 0) {
+		puts("2nd create failed");
+		return 1;
+	}
+	e = pthread_barrier_wait(&b);
+	if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("2nd barrier_wait failed");
+		return 1;
+	}
+	if (pthread_mutex_lock(&m) != 0) {
+		puts("2nd mutex_lock failed");
+		return 1;
+	}
+	if (pthread_cond_signal(&c) != 0) {
+		puts("2nd cond_signal failed");
+		return 1;
+	}
+	if (pthread_mutex_unlock(&m) != 0) {
+		puts("2nd mutex_unlock failed");
+		return 1;
+	}
+	if (pthread_join(th, &res) != 0) {
+		puts("2nd join failed");
+		return 1;
+	}
+	if (res != NULL) {
+		puts("2nd thread canceled");
+		status = 1;
+	}
 
-  printf ("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
-	  c.__data.__wseq, c.__data.__g1_start,
-	  c.__data.__g_signals[0], c.__data.__g_refs[0], c.__data.__g_size[0],
-	  c.__data.__g_signals[1], c.__data.__g_refs[1], c.__data.__g_size[1],
-	  c.__data.__g1_orig_size, c.__data.__wrefs);
+	printf("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
+	       c.__data.__wseq, c.__data.__g1_start,
+	       c.__data.__g_signals[0], c.__data.__g_refs[0],
+	       c.__data.__g_size[0], c.__data.__g_signals[1],
+	       c.__data.__g_refs[1], c.__data.__g_size[1],
+	       c.__data.__g1_orig_size, c.__data.__wrefs);
 
-  return status;
+	return status;
 }
 
 #define TEST_FUNCTION do_test ()

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -1,0 +1,248 @@
+/* Verify that condition variables synchronized by PI mutexes don't hang.
+   Copyright (C) 2012-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define THREADS_NUM 5
+#define MAXITER 50000
+
+static pthread_mutex_t mutex;
+static pthread_mutexattr_t mutex_attr;
+static pthread_cond_t cond;
+static pthread_t threads[THREADS_NUM];
+static int pending = 0;
+
+typedef void * (*threadfunc) (void *);
+
+void *
+thread_fun_timed (void *arg)
+{
+  int *ret = arg;
+  int rv, i;
+
+  printf ("Started thread_fun_timed[%d]\n", *ret);
+
+  for (i = 0; i < MAXITER / THREADS_NUM; i++)
+    {
+      rv = pthread_mutex_lock (&mutex);
+      if (rv)
+        {
+	  printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
+	  *ret = 1;
+	  goto out;
+	}
+
+      while (!pending)
+	{
+	  struct timespec ts;
+	  clock_gettime(CLOCK_REALTIME, &ts);
+	  ts.tv_sec += 20;
+	  rv = pthread_cond_timedwait (&cond, &mutex, &ts);
+
+	  /* There should be no timeout either.  */
+	  if (rv)
+            {
+	      printf ("pthread_cond_wait: %s(%d)\n", strerror (rv), rv);
+	      *ret = 1;
+	      goto out;
+	    }
+	}
+
+      pending--;
+
+      rv = pthread_mutex_unlock (&mutex);
+      if (rv)
+        {
+	  printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
+	  *ret = 1;
+	  goto out;
+	}
+    }
+
+  *ret = 0;
+
+out:
+  return ret;
+}
+
+void *
+thread_fun (void *arg)
+{
+  int *ret = arg;
+  int rv, i;
+
+  printf ("Started thread_fun[%d]\n", *ret);
+
+  for (i = 0; i < MAXITER / THREADS_NUM; i++)
+    {
+      rv = pthread_mutex_lock (&mutex);
+      if (rv)
+        {
+	  printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
+	  *ret = 1;
+	  goto out;
+	}
+
+      while (!pending)
+	{
+	  rv = pthread_cond_wait (&cond, &mutex);
+
+	  if (rv)
+            {
+	      printf ("pthread_cond_wait: %s(%d)\n", strerror (rv), rv);
+	      *ret = 1;
+	      goto out;
+	    }
+	}
+
+      pending--;
+
+      rv = pthread_mutex_unlock (&mutex);
+      if (rv)
+        {
+	  printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
+	  *ret = 1;
+	  goto out;
+	}
+    }
+
+  *ret = 0;
+
+out:
+  return ret;
+}
+
+static int
+do_test_wait (threadfunc f)
+{
+  int i;
+  int rv;
+  int counter = 0;
+  int retval[THREADS_NUM];
+
+  puts ("Starting test");
+
+  rv = pthread_mutexattr_init (&mutex_attr);
+  if (rv)
+    {
+      printf ("pthread_mutexattr_init: %s(%d)\n", strerror (rv), rv);
+      return 1;
+    }
+
+  rv = pthread_mutexattr_setprotocol (&mutex_attr, PTHREAD_PRIO_INHERIT);
+  if (rv)
+    {
+      printf ("pthread_mutexattr_setprotocol: %s(%d)\n", strerror (rv), rv);
+      return 1;
+    }
+
+  rv = pthread_mutex_init (&mutex, &mutex_attr);
+  if (rv)
+    {
+      printf ("pthread_mutex_init: %s(%d)\n", strerror (rv), rv);
+      return 1;
+    }
+
+  rv = pthread_cond_init (&cond, NULL);
+  if (rv)
+    {
+      printf ("pthread_cond_init: %s(%d)\n", strerror (rv), rv);
+      return 1;
+    }
+
+  for (i = 0; i < THREADS_NUM; i++)
+    {
+      retval[i] = i;
+      rv = pthread_create (&threads[i], NULL, f, &retval[i]);
+      if (rv)
+        {
+          printf ("pthread_create: %s(%d)\n", strerror (rv), rv);
+          return 1;
+        }
+    }
+
+  for (; counter < MAXITER; counter++)
+    {
+      rv = pthread_mutex_lock (&mutex);
+      if (rv)
+        {
+          printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
+          return 1;
+        }
+
+      if (!(counter % 100))
+	printf ("counter: %d\n", counter);
+      pending += 1;
+
+      rv = pthread_cond_signal (&cond);
+      if (rv)
+        {
+          printf ("pthread_cond_signal: %s(%d)\n", strerror (rv), rv);
+          return 1;
+        }
+
+      rv = pthread_mutex_unlock (&mutex);
+      if (rv)
+        {
+          printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
+          return 1;
+        }
+    }
+
+  for (i = 0; i < THREADS_NUM; i++)
+    {
+      void *ret;
+      rv = pthread_join (threads[i], &ret);
+      if (rv)
+        {
+          printf ("pthread_join: %s(%d)\n", strerror (rv), rv);
+          return 1;
+        }
+      if (ret && *(int *)ret)
+        {
+	  printf ("Thread %d returned with an error\n", i);
+	  return 1;
+	}
+    }
+
+  return 0;
+}
+
+static int
+do_test (void)
+{
+  puts ("Testing pthread_cond_wait");
+  int ret = do_test_wait (thread_fun);
+  if (ret)
+    return ret;
+
+  puts ("Testing pthread_cond_timedwait");
+  return do_test_wait (thread_fun_timed);
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -227,5 +227,4 @@ static int do_test(void)
 	return do_test_wait(thread_fun_timed);
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -36,212 +36,195 @@ static pthread_cond_t cond;
 static pthread_t threads[THREADS_NUM];
 static int pending = 0;
 
-typedef void * (*threadfunc) (void *);
+typedef void *(*threadfunc) (void *);
 
-void *
-thread_fun_timed (void *arg)
+void *thread_fun_timed(void *arg)
 {
-  int *ret = arg;
-  int rv, i;
+	int *ret = arg;
+	int rv, i;
 
-  printf ("Started thread_fun_timed[%d]\n", *ret);
+	printf("Started thread_fun_timed[%d]\n", *ret);
 
-  for (i = 0; i < MAXITER / THREADS_NUM; i++)
-    {
-      rv = pthread_mutex_lock (&mutex);
-      if (rv)
-        {
-	  printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
-	  *ret = 1;
-	  goto out;
+	for (i = 0; i < MAXITER / THREADS_NUM; i++) {
+		rv = pthread_mutex_lock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			       rv);
+			*ret = 1;
+			goto out;
+		}
+
+		while (!pending) {
+			struct timespec ts;
+			clock_gettime(CLOCK_REALTIME, &ts);
+			ts.tv_sec += 20;
+			rv = pthread_cond_timedwait(&cond, &mutex, &ts);
+
+			/* There should be no timeout either.  */
+			if (rv) {
+				printf("pthread_cond_wait: %s(%d)\n",
+				       strerror(rv), rv);
+				*ret = 1;
+				goto out;
+			}
+		}
+
+		pending--;
+
+		rv = pthread_mutex_unlock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			       rv);
+			*ret = 1;
+			goto out;
+		}
 	}
 
-      while (!pending)
-	{
-	  struct timespec ts;
-	  clock_gettime(CLOCK_REALTIME, &ts);
-	  ts.tv_sec += 20;
-	  rv = pthread_cond_timedwait (&cond, &mutex, &ts);
-
-	  /* There should be no timeout either.  */
-	  if (rv)
-            {
-	      printf ("pthread_cond_wait: %s(%d)\n", strerror (rv), rv);
-	      *ret = 1;
-	      goto out;
-	    }
-	}
-
-      pending--;
-
-      rv = pthread_mutex_unlock (&mutex);
-      if (rv)
-        {
-	  printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
-	  *ret = 1;
-	  goto out;
-	}
-    }
-
-  *ret = 0;
+	*ret = 0;
 
 out:
-  return ret;
+	return ret;
 }
 
-void *
-thread_fun (void *arg)
+void *thread_fun(void *arg)
 {
-  int *ret = arg;
-  int rv, i;
+	int *ret = arg;
+	int rv, i;
 
-  printf ("Started thread_fun[%d]\n", *ret);
+	printf("Started thread_fun[%d]\n", *ret);
 
-  for (i = 0; i < MAXITER / THREADS_NUM; i++)
-    {
-      rv = pthread_mutex_lock (&mutex);
-      if (rv)
-        {
-	  printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
-	  *ret = 1;
-	  goto out;
+	for (i = 0; i < MAXITER / THREADS_NUM; i++) {
+		rv = pthread_mutex_lock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			       rv);
+			*ret = 1;
+			goto out;
+		}
+
+		while (!pending) {
+			rv = pthread_cond_wait(&cond, &mutex);
+
+			if (rv) {
+				printf("pthread_cond_wait: %s(%d)\n",
+				       strerror(rv), rv);
+				*ret = 1;
+				goto out;
+			}
+		}
+
+		pending--;
+
+		rv = pthread_mutex_unlock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			       rv);
+			*ret = 1;
+			goto out;
+		}
 	}
 
-      while (!pending)
-	{
-	  rv = pthread_cond_wait (&cond, &mutex);
-
-	  if (rv)
-            {
-	      printf ("pthread_cond_wait: %s(%d)\n", strerror (rv), rv);
-	      *ret = 1;
-	      goto out;
-	    }
-	}
-
-      pending--;
-
-      rv = pthread_mutex_unlock (&mutex);
-      if (rv)
-        {
-	  printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
-	  *ret = 1;
-	  goto out;
-	}
-    }
-
-  *ret = 0;
+	*ret = 0;
 
 out:
-  return ret;
+	return ret;
 }
 
-static int
-do_test_wait (threadfunc f)
+static int do_test_wait(threadfunc f)
 {
-  int i;
-  int rv;
-  int counter = 0;
-  int retval[THREADS_NUM];
+	int i;
+	int rv;
+	int counter = 0;
+	int retval[THREADS_NUM];
 
-  puts ("Starting test");
+	puts("Starting test");
 
-  rv = pthread_mutexattr_init (&mutex_attr);
-  if (rv)
-    {
-      printf ("pthread_mutexattr_init: %s(%d)\n", strerror (rv), rv);
-      return 1;
-    }
-
-  rv = pthread_mutexattr_setprotocol (&mutex_attr, PTHREAD_PRIO_INHERIT);
-  if (rv)
-    {
-      printf ("pthread_mutexattr_setprotocol: %s(%d)\n", strerror (rv), rv);
-      return 1;
-    }
-
-  rv = pthread_mutex_init (&mutex, &mutex_attr);
-  if (rv)
-    {
-      printf ("pthread_mutex_init: %s(%d)\n", strerror (rv), rv);
-      return 1;
-    }
-
-  rv = pthread_cond_init (&cond, NULL);
-  if (rv)
-    {
-      printf ("pthread_cond_init: %s(%d)\n", strerror (rv), rv);
-      return 1;
-    }
-
-  for (i = 0; i < THREADS_NUM; i++)
-    {
-      retval[i] = i;
-      rv = pthread_create (&threads[i], NULL, f, &retval[i]);
-      if (rv)
-        {
-          printf ("pthread_create: %s(%d)\n", strerror (rv), rv);
-          return 1;
-        }
-    }
-
-  for (; counter < MAXITER; counter++)
-    {
-      rv = pthread_mutex_lock (&mutex);
-      if (rv)
-        {
-          printf ("pthread_mutex_lock: %s(%d)\n", strerror (rv), rv);
-          return 1;
-        }
-
-      if (!(counter % 100))
-	printf ("counter: %d\n", counter);
-      pending += 1;
-
-      rv = pthread_cond_signal (&cond);
-      if (rv)
-        {
-          printf ("pthread_cond_signal: %s(%d)\n", strerror (rv), rv);
-          return 1;
-        }
-
-      rv = pthread_mutex_unlock (&mutex);
-      if (rv)
-        {
-          printf ("pthread_mutex_unlock: %s(%d)\n", strerror (rv), rv);
-          return 1;
-        }
-    }
-
-  for (i = 0; i < THREADS_NUM; i++)
-    {
-      void *ret;
-      rv = pthread_join (threads[i], &ret);
-      if (rv)
-        {
-          printf ("pthread_join: %s(%d)\n", strerror (rv), rv);
-          return 1;
-        }
-      if (ret && *(int *)ret)
-        {
-	  printf ("Thread %d returned with an error\n", i);
-	  return 1;
+	rv = pthread_mutexattr_init(&mutex_attr);
+	if (rv) {
+		printf("pthread_mutexattr_init: %s(%d)\n", strerror(rv), rv);
+		return 1;
 	}
-    }
 
-  return 0;
+	rv = pthread_mutexattr_setprotocol(&mutex_attr, PTHREAD_PRIO_INHERIT);
+	if (rv) {
+		printf("pthread_mutexattr_setprotocol: %s(%d)\n", strerror(rv),
+		       rv);
+		return 1;
+	}
+
+	rv = pthread_mutex_init(&mutex, &mutex_attr);
+	if (rv) {
+		printf("pthread_mutex_init: %s(%d)\n", strerror(rv), rv);
+		return 1;
+	}
+
+	rv = pthread_cond_init(&cond, NULL);
+	if (rv) {
+		printf("pthread_cond_init: %s(%d)\n", strerror(rv), rv);
+		return 1;
+	}
+
+	for (i = 0; i < THREADS_NUM; i++) {
+		retval[i] = i;
+		rv = pthread_create(&threads[i], NULL, f, &retval[i]);
+		if (rv) {
+			printf("pthread_create: %s(%d)\n", strerror(rv), rv);
+			return 1;
+		}
+	}
+
+	for (; counter < MAXITER; counter++) {
+		rv = pthread_mutex_lock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			       rv);
+			return 1;
+		}
+
+		if (!(counter % 100))
+			printf("counter: %d\n", counter);
+		pending += 1;
+
+		rv = pthread_cond_signal(&cond);
+		if (rv) {
+			printf("pthread_cond_signal: %s(%d)\n", strerror(rv),
+			       rv);
+			return 1;
+		}
+
+		rv = pthread_mutex_unlock(&mutex);
+		if (rv) {
+			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			       rv);
+			return 1;
+		}
+	}
+
+	for (i = 0; i < THREADS_NUM; i++) {
+		void *ret;
+		rv = pthread_join(threads[i], &ret);
+		if (rv) {
+			printf("pthread_join: %s(%d)\n", strerror(rv), rv);
+			return 1;
+		}
+		if (ret && *(int *)ret) {
+			printf("Thread %d returned with an error\n", i);
+			return 1;
+		}
+	}
+
+	return 0;
 }
 
-static int
-do_test (void)
+static int do_test(void)
 {
-  puts ("Testing pthread_cond_wait");
-  int ret = do_test_wait (thread_fun);
-  if (ret)
-    return ret;
+	puts("Testing pthread_cond_wait");
+	int ret = do_test_wait(thread_fun);
+	if (ret)
+		return ret;
 
-  puts ("Testing pthread_cond_timedwait");
-  return do_test_wait (thread_fun_timed);
+	puts("Testing pthread_cond_timedwait");
+	return do_test_wait(thread_fun_timed);
 }
 
 #define TEST_FUNCTION do_test ()

--- a/tests/glibc-tests/tst-cond25.c
+++ b/tests/glibc-tests/tst-cond25.c
@@ -1,0 +1,288 @@
+/* Verify that condition variables synchronized by PI mutexes don't hang on
+   on cancellation.
+   Copyright (C) 2012-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define NUM 5
+#define ITERS 10000
+#define COUNT 100
+
+typedef void *(*thr_func) (void *);
+
+pthread_mutex_t mutex;
+pthread_cond_t cond;
+
+void cleanup (void *u)
+{
+  /* pthread_cond_wait should always return with the mutex locked.  The
+     pthread_mutex_unlock implementation does not actually check whether we
+     own the mutex for several mutex kinds, so check this explicitly.  */
+  int ret = pthread_mutex_trylock (&mutex);
+  if (ret != EDEADLK && ret != EBUSY)
+    {
+      printf ("mutex not locked in cleanup %d\n", ret);
+      abort ();
+    }
+  if (pthread_mutex_unlock (&mutex))
+    abort ();
+}
+
+void *
+signaller (void *u)
+{
+  int i, ret = 0;
+  void *tret = NULL;
+
+  for (i = 0; i < ITERS; i++)
+    {
+      if ((ret = pthread_mutex_lock (&mutex)) != 0)
+        {
+	  tret = (void *)1;
+	  printf ("signaller:mutex_lock failed: %s\n", strerror (ret));
+	  goto out;
+	}
+      if ((ret = pthread_cond_signal (&cond)) != 0)
+        {
+	  tret = (void *)1;
+	  printf ("signaller:signal failed: %s\n", strerror (ret));
+	  goto unlock_out;
+	}
+      if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+        {
+	  tret = (void *)1;
+	  printf ("signaller:mutex_unlock failed: %s\n", strerror (ret));
+	  goto out;
+	}
+      pthread_testcancel ();
+    }
+
+out:
+  return tret;
+
+unlock_out:
+  if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+    printf ("signaller:mutex_unlock[2] failed: %s\n", strerror (ret));
+  goto out;
+}
+
+void *
+waiter (void *u)
+{
+  int i, ret = 0;
+  void *tret = NULL;
+  int seq = (uintptr_t) u;
+
+  for (i = 0; i < ITERS / NUM; i++)
+    {
+      if ((ret = pthread_mutex_lock (&mutex)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:mutex_lock failed: %s\n", seq, strerror (ret));
+	  goto out;
+	}
+      pthread_cleanup_push (cleanup, NULL);
+
+      if ((ret = pthread_cond_wait (&cond, &mutex)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:wait failed: %s\n", seq, strerror (ret));
+	  goto unlock_out;
+	}
+
+      if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:mutex_unlock failed: %s\n", seq, strerror (ret));
+	  goto out;
+	}
+      pthread_cleanup_pop (0);
+    }
+
+out:
+  puts ("waiter tests done");
+  return tret;
+
+unlock_out:
+  if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+    printf ("waiter:mutex_unlock[2] failed: %s\n", strerror (ret));
+  goto out;
+}
+
+void *
+timed_waiter (void *u)
+{
+  int i, ret;
+  void *tret = NULL;
+  int seq = (uintptr_t) u;
+
+  for (i = 0; i < ITERS / NUM; i++)
+    {
+      struct timespec ts;
+
+      if ((ret = clock_gettime(CLOCK_REALTIME, &ts)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("%u:clock_gettime failed: %s\n", seq, strerror (errno));
+	  goto out;
+	}
+      ts.tv_sec += 20;
+
+      if ((ret = pthread_mutex_lock (&mutex)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:mutex_lock failed: %s\n", seq, strerror (ret));
+	  goto out;
+	}
+      pthread_cleanup_push (cleanup, NULL);
+
+      /* We should not time out either.  */
+      if ((ret = pthread_cond_timedwait (&cond, &mutex, &ts)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:timedwait failed: %s\n", seq, strerror (ret));
+	  goto unlock_out;
+	}
+      if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+        {
+	  tret = (void *) (uintptr_t) 1;
+	  printf ("waiter[%u]:mutex_unlock failed: %s\n", seq, strerror (ret));
+	  goto out;
+	}
+      pthread_cleanup_pop (0);
+    }
+
+out:
+  puts ("timed_waiter tests done");
+  return tret;
+
+unlock_out:
+  if ((ret = pthread_mutex_unlock (&mutex)) != 0)
+    printf ("waiter[%u]:mutex_unlock[2] failed: %s\n", seq, strerror (ret));
+  goto out;
+}
+
+int
+do_test_wait (thr_func f)
+{
+  pthread_t w[NUM];
+  pthread_t s;
+  pthread_mutexattr_t attr;
+  int i, j, ret = 0;
+  void *thr_ret;
+
+  for (i = 0; i < COUNT; i++)
+    {
+      if ((ret = pthread_mutexattr_init (&attr)) != 0)
+        {
+	  printf ("mutexattr_init failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      if ((ret = pthread_mutexattr_setprotocol (&attr,
+                                                PTHREAD_PRIO_INHERIT)) != 0)
+        {
+	  printf ("mutexattr_setprotocol failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      if ((ret = pthread_cond_init (&cond, NULL)) != 0)
+        {
+	  printf ("cond_init failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      if ((ret = pthread_mutex_init (&mutex, &attr)) != 0)
+        {
+	  printf ("mutex_init failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      for (j = 0; j < NUM; j++)
+        if ((ret = pthread_create (&w[j], NULL,
+                                   f, (void *) (uintptr_t) j)) != 0)
+	  {
+	    printf ("waiter[%d]: create failed: %s\n", j, strerror (ret));
+	    goto out;
+	  }
+
+      if ((ret = pthread_create (&s, NULL, signaller, NULL)) != 0)
+        {
+	  printf ("signaller: create failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      for (j = 0; j < NUM; j++)
+        {
+          pthread_cancel (w[j]);
+
+          if ((ret = pthread_join (w[j], &thr_ret)) != 0)
+	    {
+	      printf ("waiter[%d]: join failed: %s\n", j, strerror (ret));
+	      goto out;
+	    }
+
+          if (thr_ret != NULL && thr_ret != PTHREAD_CANCELED)
+	    {
+	      ret = 1;
+	      goto out;
+	    }
+        }
+
+      /* The signalling thread could have ended before it was cancelled.  */
+      pthread_cancel (s);
+
+      if ((ret = pthread_join (s, &thr_ret)) != 0)
+        {
+	  printf ("signaller: join failed: %s\n", strerror (ret));
+	  goto out;
+	}
+
+      if (thr_ret != NULL && thr_ret != PTHREAD_CANCELED)
+        {
+          ret = 1;
+          goto out;
+        }
+    }
+
+out:
+  return ret;
+}
+
+int
+do_test (int argc, char **argv)
+{
+  int ret = do_test_wait (waiter);
+
+  if (ret)
+    return ret;
+
+  return do_test_wait (timed_waiter);
+}
+
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond25.c
+++ b/tests/glibc-tests/tst-cond25.c
@@ -270,4 +270,5 @@ int do_test(int argc, char **argv)
 	return do_test_wait(timed_waiter);
 }
 
-#include "../test-skeleton.c"
+#define TEST_FUNCTION_ARGV do_test
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -1,0 +1,111 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int do_test (void);
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"
+
+/* Note that this test requires more than the standard.  It is
+   required that there are no spurious wakeups if only more readers
+   are added.  This is a reasonable demand.  */
+
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+
+
+#define N 10
+
+
+static void *
+tf (void *arg)
+{
+  int i = (long int) arg;
+  int err;
+
+  /* Get the mutex.  */
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    {
+      printf ("child %d mutex_lock failed: %s\n", i, strerror (err));
+      exit (1);
+    }
+
+  /* This call should never return.  */
+  xpthread_cond_wait (&cond, &mut);
+  puts ("error: pthread_cond_wait in tf returned");
+
+  /* We should never get here.  */
+  exit (1);
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  int err;
+  int i;
+
+  for (i = 0; i < N; ++i)
+    {
+      pthread_t th;
+
+      if (i != 0)
+	{
+	  /* Release the mutex.  */
+	  err = pthread_mutex_unlock (&mut);
+	  if (err != 0)
+	    {
+	      printf ("mutex_unlock %d failed: %s\n", i, strerror (err));
+	      return 1;
+	    }
+	}
+
+      err = pthread_create (&th, NULL, tf, (void *) (long int) i);
+      if (err != 0)
+	{
+	  printf ("create %d failed: %s\n", i, strerror (err));
+	  return 1;
+	}
+
+      /* Get the mutex.  */
+      err = pthread_mutex_lock (&mut);
+      if (err != 0)
+	{
+	  printf ("mutex_lock %d failed: %s\n", i, strerror (err));
+	  return 1;
+	}
+    }
+
+  delayed_exit (1);
+
+  /* This call should never return.  */
+  xpthread_cond_wait (&cond, &mut);
+
+  puts ("error: pthread_cond_wait in do_test returned");
+  return 1;
+}

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -23,9 +23,7 @@
 #include <unistd.h>
 
 static int do_test(void);
-
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"
 
 /* Note that this test requires more than the standard.  It is
    required that there are no spurious wakeups if only more readers

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -1,0 +1,263 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+
+int *condition;
+
+static int
+do_test (void)
+{
+  size_t ps = sysconf (_SC_PAGESIZE);
+  char tmpfname[] = "/tmp/tst-cond4.XXXXXX";
+  char data[ps];
+  void *mem;
+  int fd;
+  pthread_mutexattr_t ma;
+  pthread_mutex_t *mut1;
+  pthread_mutex_t *mut2;
+  pthread_condattr_t ca;
+  pthread_cond_t *cond;
+  pid_t pid;
+  int result = 0;
+  int p;
+
+  fd = mkstemp (tmpfname);
+  if (fd == -1)
+    {
+      printf ("cannot open temporary file: %m\n");
+      return 1;
+    }
+
+  /* Make sure it is always removed.  */
+  unlink (tmpfname);
+
+  /* Create one page of data.  */
+  memset (data, '\0', ps);
+
+  /* Write the data to the file.  */
+  if (write (fd, data, ps) != (ssize_t) ps)
+    {
+      puts ("short write");
+      return 1;
+    }
+
+  mem = mmap (NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (mem == MAP_FAILED)
+    {
+      printf ("mmap failed: %m\n");
+      return 1;
+    }
+
+  mut1 = (pthread_mutex_t *) (((uintptr_t) mem
+			       + __alignof (pthread_mutex_t))
+			      & ~(__alignof (pthread_mutex_t) - 1));
+  mut2 = mut1 + 1;
+
+  cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
+			      + __alignof (pthread_cond_t))
+			     & ~(__alignof (pthread_cond_t) - 1));
+
+  condition = (int *) (((uintptr_t) (cond + 1) + __alignof (int))
+		       & ~(__alignof (int) - 1));
+
+  if (pthread_mutexattr_init (&ma) != 0)
+    {
+      puts ("mutexattr_init failed");
+      return 1;
+    }
+
+  if (pthread_mutexattr_getpshared (&ma, &p) != 0)
+    {
+      puts ("1st mutexattr_getpshared failed");
+      return 1;
+    }
+
+  if (p != PTHREAD_PROCESS_PRIVATE)
+    {
+      puts ("default pshared value wrong");
+      return 1;
+    }
+
+  if (pthread_mutexattr_setpshared (&ma, PTHREAD_PROCESS_SHARED) != 0)
+    {
+      puts ("mutexattr_setpshared failed");
+      return 1;
+    }
+
+  if (pthread_mutexattr_getpshared (&ma, &p) != 0)
+    {
+      puts ("2nd mutexattr_getpshared failed");
+      return 1;
+    }
+
+  if (p != PTHREAD_PROCESS_SHARED)
+    {
+      puts ("pshared value after setpshared call wrong");
+      return 1;
+    }
+
+  if (pthread_mutex_init (mut1, &ma) != 0)
+    {
+      puts ("1st mutex_init failed");
+      return 1;
+    }
+
+  if (pthread_mutex_init (mut2, &ma) != 0)
+    {
+      puts ("2nd mutex_init failed");
+      return 1;
+    }
+
+  if (pthread_condattr_init (&ca) != 0)
+    {
+      puts ("condattr_init failed");
+      return 1;
+    }
+
+  if (pthread_condattr_getpshared (&ca, &p) != 0)
+    {
+      puts ("1st condattr_getpshared failed");
+      return 1;
+    }
+
+  if (p != PTHREAD_PROCESS_PRIVATE)
+    {
+      puts ("default value for pshared in condattr wrong");
+      return 1;
+    }
+
+  if (pthread_condattr_setpshared (&ca, PTHREAD_PROCESS_SHARED) != 0)
+    {
+      puts ("condattr_setpshared failed");
+      return 1;
+    }
+
+  if (pthread_condattr_getpshared (&ca, &p) != 0)
+    {
+      puts ("2nd condattr_getpshared failed");
+      return 1;
+    }
+
+  if (p != PTHREAD_PROCESS_SHARED)
+    {
+      puts ("pshared condattr still not set");
+      return 1;
+    }
+
+  if (pthread_cond_init (cond, &ca) != 0)
+    {
+      puts ("cond_init failed");
+      return 1;
+    }
+
+  if (pthread_mutex_lock (mut1) != 0)
+    {
+      puts ("parent: 1st mutex_lock failed");
+      return 1;
+    }
+
+  puts ("going to fork now");
+  pid = fork ();
+  if (pid == -1)
+    {
+      puts ("fork failed");
+      return 1;
+    }
+  else if (pid == 0)
+    {
+      if (pthread_mutex_lock (mut2) != 0)
+	{
+	  puts ("child: mutex_lock failed");
+	  return 1;
+	}
+
+      if (pthread_mutex_unlock (mut1) != 0)
+	{
+	  puts ("child: 1st mutex_unlock failed");
+	  return 1;
+	}
+
+      do
+	if (pthread_cond_wait (cond, mut2) != 0)
+	  {
+	    puts ("child: cond_wait failed");
+	    return 1;
+	  }
+      while (*condition == 0);
+
+      if (pthread_mutex_unlock (mut2) != 0)
+	{
+	  puts ("child: 2nd mutex_unlock failed");
+	  return 1;
+	}
+
+      puts ("child done");
+    }
+  else
+    {
+      int status;
+
+      if (pthread_mutex_lock (mut1) != 0)
+	{
+	  puts ("parent: 2nd mutex_lock failed");
+	  return 1;
+	}
+
+      if (pthread_mutex_lock (mut2) != 0)
+	{
+	  puts ("parent: 3rd mutex_lock failed");
+	  return 1;
+	}
+
+      if (pthread_cond_signal (cond) != 0)
+	{
+	  puts ("parent: cond_signal failed");
+	  return 1;
+	}
+
+      *condition = 1;
+
+      if (pthread_mutex_unlock (mut2) != 0)
+	{
+	  puts ("parent: mutex_unlock failed");
+	  return 1;
+	}
+
+      puts ("waiting for child");
+
+      waitpid (pid, &status, 0);
+      result |= status;
+
+      puts ("parent done");
+    }
+
+ return result;
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -26,237 +26,203 @@
 #include <sys/mman.h>
 #include <sys/wait.h>
 
-
 int *condition;
 
-static int
-do_test (void)
+static int do_test(void)
 {
-  size_t ps = sysconf (_SC_PAGESIZE);
-  char tmpfname[] = "/tmp/tst-cond4.XXXXXX";
-  char data[ps];
-  void *mem;
-  int fd;
-  pthread_mutexattr_t ma;
-  pthread_mutex_t *mut1;
-  pthread_mutex_t *mut2;
-  pthread_condattr_t ca;
-  pthread_cond_t *cond;
-  pid_t pid;
-  int result = 0;
-  int p;
+	size_t ps = sysconf(_SC_PAGESIZE);
+	char tmpfname[] = "/tmp/tst-cond4.XXXXXX";
+	char data[ps];
+	void *mem;
+	int fd;
+	pthread_mutexattr_t ma;
+	pthread_mutex_t *mut1;
+	pthread_mutex_t *mut2;
+	pthread_condattr_t ca;
+	pthread_cond_t *cond;
+	pid_t pid;
+	int result = 0;
+	int p;
 
-  fd = mkstemp (tmpfname);
-  if (fd == -1)
-    {
-      printf ("cannot open temporary file: %m\n");
-      return 1;
-    }
-
-  /* Make sure it is always removed.  */
-  unlink (tmpfname);
-
-  /* Create one page of data.  */
-  memset (data, '\0', ps);
-
-  /* Write the data to the file.  */
-  if (write (fd, data, ps) != (ssize_t) ps)
-    {
-      puts ("short write");
-      return 1;
-    }
-
-  mem = mmap (NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-  if (mem == MAP_FAILED)
-    {
-      printf ("mmap failed: %m\n");
-      return 1;
-    }
-
-  mut1 = (pthread_mutex_t *) (((uintptr_t) mem
-			       + __alignof (pthread_mutex_t))
-			      & ~(__alignof (pthread_mutex_t) - 1));
-  mut2 = mut1 + 1;
-
-  cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
-			      + __alignof (pthread_cond_t))
-			     & ~(__alignof (pthread_cond_t) - 1));
-
-  condition = (int *) (((uintptr_t) (cond + 1) + __alignof (int))
-		       & ~(__alignof (int) - 1));
-
-  if (pthread_mutexattr_init (&ma) != 0)
-    {
-      puts ("mutexattr_init failed");
-      return 1;
-    }
-
-  if (pthread_mutexattr_getpshared (&ma, &p) != 0)
-    {
-      puts ("1st mutexattr_getpshared failed");
-      return 1;
-    }
-
-  if (p != PTHREAD_PROCESS_PRIVATE)
-    {
-      puts ("default pshared value wrong");
-      return 1;
-    }
-
-  if (pthread_mutexattr_setpshared (&ma, PTHREAD_PROCESS_SHARED) != 0)
-    {
-      puts ("mutexattr_setpshared failed");
-      return 1;
-    }
-
-  if (pthread_mutexattr_getpshared (&ma, &p) != 0)
-    {
-      puts ("2nd mutexattr_getpshared failed");
-      return 1;
-    }
-
-  if (p != PTHREAD_PROCESS_SHARED)
-    {
-      puts ("pshared value after setpshared call wrong");
-      return 1;
-    }
-
-  if (pthread_mutex_init (mut1, &ma) != 0)
-    {
-      puts ("1st mutex_init failed");
-      return 1;
-    }
-
-  if (pthread_mutex_init (mut2, &ma) != 0)
-    {
-      puts ("2nd mutex_init failed");
-      return 1;
-    }
-
-  if (pthread_condattr_init (&ca) != 0)
-    {
-      puts ("condattr_init failed");
-      return 1;
-    }
-
-  if (pthread_condattr_getpshared (&ca, &p) != 0)
-    {
-      puts ("1st condattr_getpshared failed");
-      return 1;
-    }
-
-  if (p != PTHREAD_PROCESS_PRIVATE)
-    {
-      puts ("default value for pshared in condattr wrong");
-      return 1;
-    }
-
-  if (pthread_condattr_setpshared (&ca, PTHREAD_PROCESS_SHARED) != 0)
-    {
-      puts ("condattr_setpshared failed");
-      return 1;
-    }
-
-  if (pthread_condattr_getpshared (&ca, &p) != 0)
-    {
-      puts ("2nd condattr_getpshared failed");
-      return 1;
-    }
-
-  if (p != PTHREAD_PROCESS_SHARED)
-    {
-      puts ("pshared condattr still not set");
-      return 1;
-    }
-
-  if (pthread_cond_init (cond, &ca) != 0)
-    {
-      puts ("cond_init failed");
-      return 1;
-    }
-
-  if (pthread_mutex_lock (mut1) != 0)
-    {
-      puts ("parent: 1st mutex_lock failed");
-      return 1;
-    }
-
-  puts ("going to fork now");
-  pid = fork ();
-  if (pid == -1)
-    {
-      puts ("fork failed");
-      return 1;
-    }
-  else if (pid == 0)
-    {
-      if (pthread_mutex_lock (mut2) != 0)
-	{
-	  puts ("child: mutex_lock failed");
-	  return 1;
+	fd = mkstemp(tmpfname);
+	if (fd == -1) {
+		printf("cannot open temporary file: %m\n");
+		return 1;
 	}
 
-      if (pthread_mutex_unlock (mut1) != 0)
-	{
-	  puts ("child: 1st mutex_unlock failed");
-	  return 1;
+	/* Make sure it is always removed.  */
+	unlink(tmpfname);
+
+	/* Create one page of data.  */
+	memset(data, '\0', ps);
+
+	/* Write the data to the file.  */
+	if (write(fd, data, ps) != (ssize_t) ps) {
+		puts("short write");
+		return 1;
 	}
 
-      do
-	if (pthread_cond_wait (cond, mut2) != 0)
-	  {
-	    puts ("child: cond_wait failed");
-	    return 1;
-	  }
-      while (*condition == 0);
-
-      if (pthread_mutex_unlock (mut2) != 0)
-	{
-	  puts ("child: 2nd mutex_unlock failed");
-	  return 1;
+	mem = mmap(NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (mem == MAP_FAILED) {
+		printf("mmap failed: %m\n");
+		return 1;
 	}
 
-      puts ("child done");
-    }
-  else
-    {
-      int status;
+	mut1 = (pthread_mutex_t *) (((uintptr_t) mem
+				     + __alignof(pthread_mutex_t))
+				    & ~(__alignof(pthread_mutex_t) - 1));
+	mut2 = mut1 + 1;
 
-      if (pthread_mutex_lock (mut1) != 0)
-	{
-	  puts ("parent: 2nd mutex_lock failed");
-	  return 1;
+	cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
+				    + __alignof(pthread_cond_t))
+				   & ~(__alignof(pthread_cond_t) - 1));
+
+	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
+			    & ~(__alignof(int) - 1));
+
+	if (pthread_mutexattr_init(&ma) != 0) {
+		puts("mutexattr_init failed");
+		return 1;
 	}
 
-      if (pthread_mutex_lock (mut2) != 0)
-	{
-	  puts ("parent: 3rd mutex_lock failed");
-	  return 1;
+	if (pthread_mutexattr_getpshared(&ma, &p) != 0) {
+		puts("1st mutexattr_getpshared failed");
+		return 1;
 	}
 
-      if (pthread_cond_signal (cond) != 0)
-	{
-	  puts ("parent: cond_signal failed");
-	  return 1;
+	if (p != PTHREAD_PROCESS_PRIVATE) {
+		puts("default pshared value wrong");
+		return 1;
 	}
 
-      *condition = 1;
-
-      if (pthread_mutex_unlock (mut2) != 0)
-	{
-	  puts ("parent: mutex_unlock failed");
-	  return 1;
+	if (pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED) != 0) {
+		puts("mutexattr_setpshared failed");
+		return 1;
 	}
 
-      puts ("waiting for child");
+	if (pthread_mutexattr_getpshared(&ma, &p) != 0) {
+		puts("2nd mutexattr_getpshared failed");
+		return 1;
+	}
 
-      waitpid (pid, &status, 0);
-      result |= status;
+	if (p != PTHREAD_PROCESS_SHARED) {
+		puts("pshared value after setpshared call wrong");
+		return 1;
+	}
 
-      puts ("parent done");
-    }
+	if (pthread_mutex_init(mut1, &ma) != 0) {
+		puts("1st mutex_init failed");
+		return 1;
+	}
 
- return result;
+	if (pthread_mutex_init(mut2, &ma) != 0) {
+		puts("2nd mutex_init failed");
+		return 1;
+	}
+
+	if (pthread_condattr_init(&ca) != 0) {
+		puts("condattr_init failed");
+		return 1;
+	}
+
+	if (pthread_condattr_getpshared(&ca, &p) != 0) {
+		puts("1st condattr_getpshared failed");
+		return 1;
+	}
+
+	if (p != PTHREAD_PROCESS_PRIVATE) {
+		puts("default value for pshared in condattr wrong");
+		return 1;
+	}
+
+	if (pthread_condattr_setpshared(&ca, PTHREAD_PROCESS_SHARED) != 0) {
+		puts("condattr_setpshared failed");
+		return 1;
+	}
+
+	if (pthread_condattr_getpshared(&ca, &p) != 0) {
+		puts("2nd condattr_getpshared failed");
+		return 1;
+	}
+
+	if (p != PTHREAD_PROCESS_SHARED) {
+		puts("pshared condattr still not set");
+		return 1;
+	}
+
+	if (pthread_cond_init(cond, &ca) != 0) {
+		puts("cond_init failed");
+		return 1;
+	}
+
+	if (pthread_mutex_lock(mut1) != 0) {
+		puts("parent: 1st mutex_lock failed");
+		return 1;
+	}
+
+	puts("going to fork now");
+	pid = fork();
+	if (pid == -1) {
+		puts("fork failed");
+		return 1;
+	} else if (pid == 0) {
+		if (pthread_mutex_lock(mut2) != 0) {
+			puts("child: mutex_lock failed");
+			return 1;
+		}
+
+		if (pthread_mutex_unlock(mut1) != 0) {
+			puts("child: 1st mutex_unlock failed");
+			return 1;
+		}
+
+		do
+			if (pthread_cond_wait(cond, mut2) != 0) {
+				puts("child: cond_wait failed");
+				return 1;
+			}
+		while (*condition == 0) ;
+
+		if (pthread_mutex_unlock(mut2) != 0) {
+			puts("child: 2nd mutex_unlock failed");
+			return 1;
+		}
+
+		puts("child done");
+	} else {
+		int status;
+
+		if (pthread_mutex_lock(mut1) != 0) {
+			puts("parent: 2nd mutex_lock failed");
+			return 1;
+		}
+
+		if (pthread_mutex_lock(mut2) != 0) {
+			puts("parent: 3rd mutex_lock failed");
+			return 1;
+		}
+
+		if (pthread_cond_signal(cond) != 0) {
+			puts("parent: cond_signal failed");
+			return 1;
+		}
+
+		*condition = 1;
+
+		if (pthread_mutex_unlock(mut2) != 0) {
+			puts("parent: mutex_unlock failed");
+			return 1;
+		}
+
+		puts("waiting for child");
+
+		waitpid(pid, &status, 0);
+		result |= status;
+
+		puts("parent done");
+	}
+
+	return result;
 }
 
 #define TEST_FUNCTION do_test ()

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -225,5 +225,4 @@ static int do_test(void)
 	return result;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -1,0 +1,105 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+
+
+static pthread_mutex_t mut;
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+
+static int
+do_test (void)
+{
+  pthread_mutexattr_t ma;
+  int err;
+  struct timespec ts;
+  struct timeval tv;
+
+  if (pthread_mutexattr_init (&ma) != 0)
+    {
+      puts ("mutexattr_init failed");
+      exit (1);
+    }
+
+  if (pthread_mutexattr_settype (&ma, PTHREAD_MUTEX_ERRORCHECK) != 0)
+    {
+      puts ("mutexattr_settype failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_init (&mut, &ma) != 0)
+    {
+      puts ("mutex_init failed");
+      exit (1);
+    }
+
+  /* Get the mutex.  */
+  if (pthread_mutex_lock (&mut) != 0)
+    {
+      puts ("mutex_lock failed");
+      exit (1);
+    }
+
+  /* Waiting for the condition will fail.  But we want the timeout here.  */
+  if (gettimeofday (&tv, NULL) != 0)
+    {
+      puts ("gettimeofday failed");
+      exit (1);
+    }
+
+  TIMEVAL_TO_TIMESPEC (&tv, &ts);
+  ts.tv_nsec += 500000000;
+  if (ts.tv_nsec >= 1000000000)
+    {
+      ts.tv_nsec -= 1000000000;
+      ++ts.tv_sec;
+    }
+  err = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (err == 0)
+    {
+      /* This could in theory happen but here without any signal and
+	 additional waiter it should not.  */
+      puts ("cond_timedwait succeeded");
+      exit (1);
+    }
+  else if (err != ETIMEDOUT)
+    {
+      printf ("cond_timedwait returned with %s\n", strerror (err));
+      exit (1);
+    }
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    {
+      printf ("mutex_unlock failed: %s\n", strerror (err));
+      exit (1);
+    }
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -87,5 +87,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -24,82 +24,68 @@
 #include <time.h>
 #include <sys/time.h>
 
-
 static pthread_mutex_t mut;
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  pthread_mutexattr_t ma;
-  int err;
-  struct timespec ts;
-  struct timeval tv;
+	pthread_mutexattr_t ma;
+	int err;
+	struct timespec ts;
+	struct timeval tv;
 
-  if (pthread_mutexattr_init (&ma) != 0)
-    {
-      puts ("mutexattr_init failed");
-      exit (1);
-    }
+	if (pthread_mutexattr_init(&ma) != 0) {
+		puts("mutexattr_init failed");
+		exit(1);
+	}
 
-  if (pthread_mutexattr_settype (&ma, PTHREAD_MUTEX_ERRORCHECK) != 0)
-    {
-      puts ("mutexattr_settype failed");
-      exit (1);
-    }
+	if (pthread_mutexattr_settype(&ma, PTHREAD_MUTEX_ERRORCHECK) != 0) {
+		puts("mutexattr_settype failed");
+		exit(1);
+	}
 
-  if (pthread_mutex_init (&mut, &ma) != 0)
-    {
-      puts ("mutex_init failed");
-      exit (1);
-    }
+	if (pthread_mutex_init(&mut, &ma) != 0) {
+		puts("mutex_init failed");
+		exit(1);
+	}
 
-  /* Get the mutex.  */
-  if (pthread_mutex_lock (&mut) != 0)
-    {
-      puts ("mutex_lock failed");
-      exit (1);
-    }
+	/* Get the mutex.  */
+	if (pthread_mutex_lock(&mut) != 0) {
+		puts("mutex_lock failed");
+		exit(1);
+	}
 
-  /* Waiting for the condition will fail.  But we want the timeout here.  */
-  if (gettimeofday (&tv, NULL) != 0)
-    {
-      puts ("gettimeofday failed");
-      exit (1);
-    }
+	/* Waiting for the condition will fail.  But we want the timeout here.  */
+	if (gettimeofday(&tv, NULL) != 0) {
+		puts("gettimeofday failed");
+		exit(1);
+	}
 
-  TIMEVAL_TO_TIMESPEC (&tv, &ts);
-  ts.tv_nsec += 500000000;
-  if (ts.tv_nsec >= 1000000000)
-    {
-      ts.tv_nsec -= 1000000000;
-      ++ts.tv_sec;
-    }
-  err = pthread_cond_timedwait (&cond, &mut, &ts);
-  if (err == 0)
-    {
-      /* This could in theory happen but here without any signal and
-	 additional waiter it should not.  */
-      puts ("cond_timedwait succeeded");
-      exit (1);
-    }
-  else if (err != ETIMEDOUT)
-    {
-      printf ("cond_timedwait returned with %s\n", strerror (err));
-      exit (1);
-    }
+	TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	ts.tv_nsec += 500000000;
+	if (ts.tv_nsec >= 1000000000) {
+		ts.tv_nsec -= 1000000000;
+		++ts.tv_sec;
+	}
+	err = pthread_cond_timedwait(&cond, &mut, &ts);
+	if (err == 0) {
+		/* This could in theory happen but here without any signal and
+		   additional waiter it should not.  */
+		puts("cond_timedwait succeeded");
+		exit(1);
+	} else if (err != ETIMEDOUT) {
+		printf("cond_timedwait returned with %s\n", strerror(err));
+		exit(1);
+	}
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    {
-      printf ("mutex_unlock failed: %s\n", strerror (err));
-      exit (1);
-    }
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0) {
+		printf("mutex_unlock failed: %s\n", strerror(err));
+		exit(1);
+	}
 
-  return 0;
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -1,0 +1,233 @@
+/* Copyright (C) 2002-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2002.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+
+
+int *condition;
+
+static int
+do_test (void)
+{
+  size_t ps = sysconf (_SC_PAGESIZE);
+  char tmpfname[] = "/tmp/tst-cond6.XXXXXX";
+  char data[ps];
+  void *mem;
+  int fd;
+  pthread_mutexattr_t ma;
+  pthread_mutex_t *mut1;
+  pthread_mutex_t *mut2;
+  pthread_condattr_t ca;
+  pthread_cond_t *cond;
+  pid_t pid;
+  int result = 0;
+
+  fd = mkstemp (tmpfname);
+  if (fd == -1)
+    {
+      printf ("cannot open temporary file: %m\n");
+      exit (1);
+    }
+
+  /* Make sure it is always removed.  */
+  unlink (tmpfname);
+
+  /* Create one page of data.  */
+  memset (data, '\0', ps);
+
+  /* Write the data to the file.  */
+  if (write (fd, data, ps) != (ssize_t) ps)
+    {
+      puts ("short write");
+      exit (1);
+    }
+
+  mem = mmap (NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (mem == MAP_FAILED)
+    {
+      printf ("mmap failed: %m\n");
+      exit (1);
+    }
+
+  mut1 = (pthread_mutex_t *) (((uintptr_t) mem
+			       + __alignof (pthread_mutex_t))
+			      & ~(__alignof (pthread_mutex_t) - 1));
+  mut2 = mut1 + 1;
+
+  cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
+			      + __alignof (pthread_cond_t))
+			     & ~(__alignof (pthread_cond_t) - 1));
+
+  condition = (int *) (((uintptr_t) (cond + 1) + __alignof (int))
+		       & ~(__alignof (int) - 1));
+
+  if (pthread_mutexattr_init (&ma) != 0)
+    {
+      puts ("mutexattr_init failed");
+      exit (1);
+    }
+
+  if (pthread_mutexattr_setpshared (&ma, PTHREAD_PROCESS_SHARED) != 0)
+    {
+      puts ("mutexattr_setpshared failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_init (mut1, &ma) != 0)
+    {
+      puts ("1st mutex_init failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_init (mut2, &ma) != 0)
+    {
+      puts ("2nd mutex_init failed");
+      exit (1);
+    }
+
+  if (pthread_condattr_init (&ca) != 0)
+    {
+      puts ("condattr_init failed");
+      exit (1);
+    }
+
+  if (pthread_condattr_setpshared (&ca, PTHREAD_PROCESS_SHARED) != 0)
+    {
+      puts ("condattr_setpshared failed");
+      exit (1);
+    }
+
+  if (pthread_cond_init (cond, &ca) != 0)
+    {
+      puts ("cond_init failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_lock (mut1) != 0)
+    {
+      puts ("parent: 1st mutex_lock failed");
+      exit (1);
+    }
+
+  puts ("going to fork now");
+  pid = fork ();
+  if (pid == -1)
+    {
+      puts ("fork failed");
+      exit (1);
+    }
+  else if (pid == 0)
+    {
+      struct timespec ts;
+      struct timeval tv;
+
+      if (pthread_mutex_lock (mut2) != 0)
+	{
+	  puts ("child: mutex_lock failed");
+	  exit (1);
+	}
+
+      if (pthread_mutex_unlock (mut1) != 0)
+	{
+	  puts ("child: 1st mutex_unlock failed");
+	  exit (1);
+	}
+
+      if (gettimeofday (&tv, NULL) != 0)
+	{
+	  puts ("gettimeofday failed");
+	  exit (1);
+	}
+
+      TIMEVAL_TO_TIMESPEC (&tv, &ts);
+      ts.tv_nsec += 500000000;
+      if (ts.tv_nsec >= 1000000000)
+	{
+	  ts.tv_nsec -= 1000000000;
+	  ++ts.tv_sec;
+	}
+
+      do
+	if (pthread_cond_timedwait (cond, mut2, &ts) != 0)
+	  {
+	    puts ("child: cond_wait failed");
+	    exit (1);
+	  }
+      while (*condition == 0);
+
+      if (pthread_mutex_unlock (mut2) != 0)
+	{
+	  puts ("child: 2nd mutex_unlock failed");
+	  exit (1);
+	}
+
+      puts ("child done");
+    }
+  else
+    {
+      int status;
+
+      if (pthread_mutex_lock (mut1) != 0)
+	{
+	  puts ("parent: 2nd mutex_lock failed");
+	  exit (1);
+	}
+
+      if (pthread_mutex_lock (mut2) != 0)
+	{
+	  puts ("parent: 3rd mutex_lock failed");
+	  exit (1);
+	}
+
+      if (pthread_cond_signal (cond) != 0)
+	{
+	  puts ("parent: cond_signal failed");
+	  exit (1);
+	}
+
+      *condition = 1;
+
+      if (pthread_mutex_unlock (mut2) != 0)
+	{
+	  puts ("parent: mutex_unlock failed");
+	  exit (1);
+	}
+
+      puts ("waiting for child");
+
+      waitpid (pid, &status, 0);
+      result |= status;
+
+      puts ("parent done");
+    }
+
+ return result;
+}
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -28,205 +28,177 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 
-
 int *condition;
 
-static int
-do_test (void)
+static int do_test(void)
 {
-  size_t ps = sysconf (_SC_PAGESIZE);
-  char tmpfname[] = "/tmp/tst-cond6.XXXXXX";
-  char data[ps];
-  void *mem;
-  int fd;
-  pthread_mutexattr_t ma;
-  pthread_mutex_t *mut1;
-  pthread_mutex_t *mut2;
-  pthread_condattr_t ca;
-  pthread_cond_t *cond;
-  pid_t pid;
-  int result = 0;
+	size_t ps = sysconf(_SC_PAGESIZE);
+	char tmpfname[] = "/tmp/tst-cond6.XXXXXX";
+	char data[ps];
+	void *mem;
+	int fd;
+	pthread_mutexattr_t ma;
+	pthread_mutex_t *mut1;
+	pthread_mutex_t *mut2;
+	pthread_condattr_t ca;
+	pthread_cond_t *cond;
+	pid_t pid;
+	int result = 0;
 
-  fd = mkstemp (tmpfname);
-  if (fd == -1)
-    {
-      printf ("cannot open temporary file: %m\n");
-      exit (1);
-    }
-
-  /* Make sure it is always removed.  */
-  unlink (tmpfname);
-
-  /* Create one page of data.  */
-  memset (data, '\0', ps);
-
-  /* Write the data to the file.  */
-  if (write (fd, data, ps) != (ssize_t) ps)
-    {
-      puts ("short write");
-      exit (1);
-    }
-
-  mem = mmap (NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-  if (mem == MAP_FAILED)
-    {
-      printf ("mmap failed: %m\n");
-      exit (1);
-    }
-
-  mut1 = (pthread_mutex_t *) (((uintptr_t) mem
-			       + __alignof (pthread_mutex_t))
-			      & ~(__alignof (pthread_mutex_t) - 1));
-  mut2 = mut1 + 1;
-
-  cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
-			      + __alignof (pthread_cond_t))
-			     & ~(__alignof (pthread_cond_t) - 1));
-
-  condition = (int *) (((uintptr_t) (cond + 1) + __alignof (int))
-		       & ~(__alignof (int) - 1));
-
-  if (pthread_mutexattr_init (&ma) != 0)
-    {
-      puts ("mutexattr_init failed");
-      exit (1);
-    }
-
-  if (pthread_mutexattr_setpshared (&ma, PTHREAD_PROCESS_SHARED) != 0)
-    {
-      puts ("mutexattr_setpshared failed");
-      exit (1);
-    }
-
-  if (pthread_mutex_init (mut1, &ma) != 0)
-    {
-      puts ("1st mutex_init failed");
-      exit (1);
-    }
-
-  if (pthread_mutex_init (mut2, &ma) != 0)
-    {
-      puts ("2nd mutex_init failed");
-      exit (1);
-    }
-
-  if (pthread_condattr_init (&ca) != 0)
-    {
-      puts ("condattr_init failed");
-      exit (1);
-    }
-
-  if (pthread_condattr_setpshared (&ca, PTHREAD_PROCESS_SHARED) != 0)
-    {
-      puts ("condattr_setpshared failed");
-      exit (1);
-    }
-
-  if (pthread_cond_init (cond, &ca) != 0)
-    {
-      puts ("cond_init failed");
-      exit (1);
-    }
-
-  if (pthread_mutex_lock (mut1) != 0)
-    {
-      puts ("parent: 1st mutex_lock failed");
-      exit (1);
-    }
-
-  puts ("going to fork now");
-  pid = fork ();
-  if (pid == -1)
-    {
-      puts ("fork failed");
-      exit (1);
-    }
-  else if (pid == 0)
-    {
-      struct timespec ts;
-      struct timeval tv;
-
-      if (pthread_mutex_lock (mut2) != 0)
-	{
-	  puts ("child: mutex_lock failed");
-	  exit (1);
+	fd = mkstemp(tmpfname);
+	if (fd == -1) {
+		printf("cannot open temporary file: %m\n");
+		exit(1);
 	}
 
-      if (pthread_mutex_unlock (mut1) != 0)
-	{
-	  puts ("child: 1st mutex_unlock failed");
-	  exit (1);
+	/* Make sure it is always removed.  */
+	unlink(tmpfname);
+
+	/* Create one page of data.  */
+	memset(data, '\0', ps);
+
+	/* Write the data to the file.  */
+	if (write(fd, data, ps) != (ssize_t) ps) {
+		puts("short write");
+		exit(1);
 	}
 
-      if (gettimeofday (&tv, NULL) != 0)
-	{
-	  puts ("gettimeofday failed");
-	  exit (1);
+	mem = mmap(NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (mem == MAP_FAILED) {
+		printf("mmap failed: %m\n");
+		exit(1);
 	}
 
-      TIMEVAL_TO_TIMESPEC (&tv, &ts);
-      ts.tv_nsec += 500000000;
-      if (ts.tv_nsec >= 1000000000)
-	{
-	  ts.tv_nsec -= 1000000000;
-	  ++ts.tv_sec;
+	mut1 = (pthread_mutex_t *) (((uintptr_t) mem
+				     + __alignof(pthread_mutex_t))
+				    & ~(__alignof(pthread_mutex_t) - 1));
+	mut2 = mut1 + 1;
+
+	cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
+				    + __alignof(pthread_cond_t))
+				   & ~(__alignof(pthread_cond_t) - 1));
+
+	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
+			    & ~(__alignof(int) - 1));
+
+	if (pthread_mutexattr_init(&ma) != 0) {
+		puts("mutexattr_init failed");
+		exit(1);
 	}
 
-      do
-	if (pthread_cond_timedwait (cond, mut2, &ts) != 0)
-	  {
-	    puts ("child: cond_wait failed");
-	    exit (1);
-	  }
-      while (*condition == 0);
-
-      if (pthread_mutex_unlock (mut2) != 0)
-	{
-	  puts ("child: 2nd mutex_unlock failed");
-	  exit (1);
+	if (pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED) != 0) {
+		puts("mutexattr_setpshared failed");
+		exit(1);
 	}
 
-      puts ("child done");
-    }
-  else
-    {
-      int status;
-
-      if (pthread_mutex_lock (mut1) != 0)
-	{
-	  puts ("parent: 2nd mutex_lock failed");
-	  exit (1);
+	if (pthread_mutex_init(mut1, &ma) != 0) {
+		puts("1st mutex_init failed");
+		exit(1);
 	}
 
-      if (pthread_mutex_lock (mut2) != 0)
-	{
-	  puts ("parent: 3rd mutex_lock failed");
-	  exit (1);
+	if (pthread_mutex_init(mut2, &ma) != 0) {
+		puts("2nd mutex_init failed");
+		exit(1);
 	}
 
-      if (pthread_cond_signal (cond) != 0)
-	{
-	  puts ("parent: cond_signal failed");
-	  exit (1);
+	if (pthread_condattr_init(&ca) != 0) {
+		puts("condattr_init failed");
+		exit(1);
 	}
 
-      *condition = 1;
-
-      if (pthread_mutex_unlock (mut2) != 0)
-	{
-	  puts ("parent: mutex_unlock failed");
-	  exit (1);
+	if (pthread_condattr_setpshared(&ca, PTHREAD_PROCESS_SHARED) != 0) {
+		puts("condattr_setpshared failed");
+		exit(1);
 	}
 
-      puts ("waiting for child");
+	if (pthread_cond_init(cond, &ca) != 0) {
+		puts("cond_init failed");
+		exit(1);
+	}
 
-      waitpid (pid, &status, 0);
-      result |= status;
+	if (pthread_mutex_lock(mut1) != 0) {
+		puts("parent: 1st mutex_lock failed");
+		exit(1);
+	}
 
-      puts ("parent done");
-    }
+	puts("going to fork now");
+	pid = fork();
+	if (pid == -1) {
+		puts("fork failed");
+		exit(1);
+	} else if (pid == 0) {
+		struct timespec ts;
+		struct timeval tv;
 
- return result;
+		if (pthread_mutex_lock(mut2) != 0) {
+			puts("child: mutex_lock failed");
+			exit(1);
+		}
+
+		if (pthread_mutex_unlock(mut1) != 0) {
+			puts("child: 1st mutex_unlock failed");
+			exit(1);
+		}
+
+		if (gettimeofday(&tv, NULL) != 0) {
+			puts("gettimeofday failed");
+			exit(1);
+		}
+
+		TIMEVAL_TO_TIMESPEC(&tv, &ts);
+		ts.tv_nsec += 500000000;
+		if (ts.tv_nsec >= 1000000000) {
+			ts.tv_nsec -= 1000000000;
+			++ts.tv_sec;
+		}
+
+		do
+			if (pthread_cond_timedwait(cond, mut2, &ts) != 0) {
+				puts("child: cond_wait failed");
+				exit(1);
+			}
+		while (*condition == 0) ;
+
+		if (pthread_mutex_unlock(mut2) != 0) {
+			puts("child: 2nd mutex_unlock failed");
+			exit(1);
+		}
+
+		puts("child done");
+	} else {
+		int status;
+
+		if (pthread_mutex_lock(mut1) != 0) {
+			puts("parent: 2nd mutex_lock failed");
+			exit(1);
+		}
+
+		if (pthread_mutex_lock(mut2) != 0) {
+			puts("parent: 3rd mutex_lock failed");
+			exit(1);
+		}
+
+		if (pthread_cond_signal(cond) != 0) {
+			puts("parent: cond_signal failed");
+			exit(1);
+		}
+
+		*condition = 1;
+
+		if (pthread_mutex_unlock(mut2) != 0) {
+			puts("parent: mutex_unlock failed");
+			exit(1);
+		}
+
+		puts("waiting for child");
+
+		waitpid(pid, &status, 0);
+		result |= status;
+
+		puts("parent done");
+	}
+
+	return result;
 }
 
 #define TEST_FUNCTION do_test ()

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -201,5 +201,4 @@ static int do_test(void)
 	return result;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -1,0 +1,167 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Jakub Jelinek <jakub@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+
+
+typedef struct
+  {
+    pthread_cond_t cond;
+    pthread_mutex_t lock;
+    pthread_t h;
+  } T;
+
+
+static volatile bool done;
+
+
+static void *
+tf (void *arg)
+{
+  puts ("child created");
+
+  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
+      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+    {
+      puts ("cannot set cancellation options");
+      exit (1);
+    }
+
+  T *t = (T *) arg;
+
+  if (pthread_mutex_lock (&t->lock) != 0)
+    {
+      puts ("child: lock failed");
+      exit (1);
+    }
+
+  done = true;
+
+  if (pthread_cond_signal (&t->cond) != 0)
+    {
+      puts ("child: cond_signal failed");
+      exit (1);
+    }
+
+  if (pthread_cond_wait (&t->cond, &t->lock) != 0)
+    {
+      puts ("child: cond_wait failed");
+      exit (1);
+    }
+
+  if (pthread_mutex_unlock (&t->lock) != 0)
+    {
+      puts ("child: unlock failed");
+      exit (1);
+    }
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  int i;
+#define N 100
+  T *t[N];
+  for (i = 0; i < N; ++i)
+    {
+      printf ("round %d\n", i);
+
+      t[i] = (T *) malloc (sizeof (T));
+      if (t[i] == NULL)
+	{
+	  puts ("out of memory");
+	  exit (1);
+	}
+
+      if (pthread_mutex_init (&t[i]->lock, NULL) != 0
+	  || pthread_cond_init (&t[i]->cond, NULL) != 0)
+	{
+	  puts ("an _init function failed");
+	  exit (1);
+	}
+
+      if (pthread_mutex_lock (&t[i]->lock) != 0)
+	{
+	  puts ("initial mutex_lock failed");
+	  exit (1);
+	}
+
+      done = false;
+
+      if (pthread_create (&t[i]->h, NULL, tf, t[i]) != 0)
+	{
+	  puts ("pthread_create failed");
+	  exit (1);
+	}
+
+      do
+	if (pthread_cond_wait (&t[i]->cond, &t[i]->lock) != 0)
+	  {
+	    puts ("cond_wait failed");
+	    exit (1);
+	  }
+      while (! done);
+
+      /* Release the lock since the cancel handler will get it.  */
+      if (pthread_mutex_unlock (&t[i]->lock) != 0)
+	{
+	  puts ("mutex_unlock failed");
+	  exit (1);
+	}
+
+      if (pthread_cancel (t[i]->h) != 0)
+	{
+	  puts ("cancel failed");
+	  exit (1);
+	}
+
+      puts ("parent: joining now");
+
+      void *result;
+      if (pthread_join (t[i]->h, &result) != 0)
+	{
+	  puts ("join failed");
+	  exit (1);
+	}
+
+      if (result != PTHREAD_CANCELED)
+	{
+	  puts ("result != PTHREAD_CANCELED");
+	  exit (1);
+	}
+    }
+
+  for (i = 0; i < N; ++i)
+    free (t[i]);
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -25,143 +25,120 @@
 #include <time.h>
 #include <sys/time.h>
 
-
-typedef struct
-  {
-    pthread_cond_t cond;
-    pthread_mutex_t lock;
-    pthread_t h;
-  } T;
-
+typedef struct {
+	pthread_cond_t cond;
+	pthread_mutex_t lock;
+	pthread_t h;
+} T;
 
 static volatile bool done;
 
-
-static void *
-tf (void *arg)
+static void *tf(void *arg)
 {
-  puts ("child created");
+	puts("child created");
 
-  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
-      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-    {
-      puts ("cannot set cancellation options");
-      exit (1);
-    }
+	if (pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0
+	    || pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0) {
+		puts("cannot set cancellation options");
+		exit(1);
+	}
 
-  T *t = (T *) arg;
+	T *t = (T *) arg;
 
-  if (pthread_mutex_lock (&t->lock) != 0)
-    {
-      puts ("child: lock failed");
-      exit (1);
-    }
+	if (pthread_mutex_lock(&t->lock) != 0) {
+		puts("child: lock failed");
+		exit(1);
+	}
 
-  done = true;
+	done = true;
 
-  if (pthread_cond_signal (&t->cond) != 0)
-    {
-      puts ("child: cond_signal failed");
-      exit (1);
-    }
+	if (pthread_cond_signal(&t->cond) != 0) {
+		puts("child: cond_signal failed");
+		exit(1);
+	}
 
-  if (pthread_cond_wait (&t->cond, &t->lock) != 0)
-    {
-      puts ("child: cond_wait failed");
-      exit (1);
-    }
+	if (pthread_cond_wait(&t->cond, &t->lock) != 0) {
+		puts("child: cond_wait failed");
+		exit(1);
+	}
 
-  if (pthread_mutex_unlock (&t->lock) != 0)
-    {
-      puts ("child: unlock failed");
-      exit (1);
-    }
+	if (pthread_mutex_unlock(&t->lock) != 0) {
+		puts("child: unlock failed");
+		exit(1);
+	}
 
-  return NULL;
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  int i;
+	int i;
 #define N 100
-  T *t[N];
-  for (i = 0; i < N; ++i)
-    {
-      printf ("round %d\n", i);
+	T *t[N];
+	for (i = 0; i < N; ++i) {
+		printf("round %d\n", i);
 
-      t[i] = (T *) malloc (sizeof (T));
-      if (t[i] == NULL)
-	{
-	  puts ("out of memory");
-	  exit (1);
+		t[i] = (T *) malloc(sizeof(T));
+		if (t[i] == NULL) {
+			puts("out of memory");
+			exit(1);
+		}
+
+		if (pthread_mutex_init(&t[i]->lock, NULL) != 0
+		    || pthread_cond_init(&t[i]->cond, NULL) != 0) {
+			puts("an _init function failed");
+			exit(1);
+		}
+
+		if (pthread_mutex_lock(&t[i]->lock) != 0) {
+			puts("initial mutex_lock failed");
+			exit(1);
+		}
+
+		done = false;
+
+		if (pthread_create(&t[i]->h, NULL, tf, t[i]) != 0) {
+			puts("pthread_create failed");
+			exit(1);
+		}
+
+		do
+			if (pthread_cond_wait(&t[i]->cond, &t[i]->lock) != 0) {
+				puts("cond_wait failed");
+				exit(1);
+			}
+		while (!done) ;
+
+		/* Release the lock since the cancel handler will get it.  */
+		if (pthread_mutex_unlock(&t[i]->lock) != 0) {
+			puts("mutex_unlock failed");
+			exit(1);
+		}
+
+		if (pthread_cancel(t[i]->h) != 0) {
+			puts("cancel failed");
+			exit(1);
+		}
+
+		puts("parent: joining now");
+
+		void *result;
+		if (pthread_join(t[i]->h, &result) != 0) {
+			puts("join failed");
+			exit(1);
+		}
+
+		if (result != PTHREAD_CANCELED) {
+			puts("result != PTHREAD_CANCELED");
+			exit(1);
+		}
 	}
 
-      if (pthread_mutex_init (&t[i]->lock, NULL) != 0
-	  || pthread_cond_init (&t[i]->cond, NULL) != 0)
-	{
-	  puts ("an _init function failed");
-	  exit (1);
-	}
+	for (i = 0; i < N; ++i)
+		free(t[i]);
 
-      if (pthread_mutex_lock (&t[i]->lock) != 0)
-	{
-	  puts ("initial mutex_lock failed");
-	  exit (1);
-	}
-
-      done = false;
-
-      if (pthread_create (&t[i]->h, NULL, tf, t[i]) != 0)
-	{
-	  puts ("pthread_create failed");
-	  exit (1);
-	}
-
-      do
-	if (pthread_cond_wait (&t[i]->cond, &t[i]->lock) != 0)
-	  {
-	    puts ("cond_wait failed");
-	    exit (1);
-	  }
-      while (! done);
-
-      /* Release the lock since the cancel handler will get it.  */
-      if (pthread_mutex_unlock (&t[i]->lock) != 0)
-	{
-	  puts ("mutex_unlock failed");
-	  exit (1);
-	}
-
-      if (pthread_cancel (t[i]->h) != 0)
-	{
-	  puts ("cancel failed");
-	  exit (1);
-	}
-
-      puts ("parent: joining now");
-
-      void *result;
-      if (pthread_join (t[i]->h, &result) != 0)
-	{
-	  puts ("join failed");
-	  exit (1);
-	}
-
-      if (result != PTHREAD_CANCELED)
-	{
-	  puts ("result != PTHREAD_CANCELED");
-	  exit (1);
-	}
-    }
-
-  for (i = 0; i < N; ++i)
-    free (t[i]);
-
-  return 0;
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -140,5 +140,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -1,0 +1,276 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
+
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+
+static pthread_barrier_t bar;
+
+
+static void
+ch (void *arg)
+{
+  int e = pthread_mutex_lock (&mut);
+  if (e == 0)
+    {
+      puts ("mutex not locked at all by cond_wait");
+      exit (1);
+    }
+
+  if (e != EDEADLK)
+    {
+      puts ("no deadlock error signaled");
+      exit (1);
+    }
+
+  if (pthread_mutex_unlock (&mut) != 0)
+    {
+      puts ("ch: cannot unlock mutex");
+      exit (1);
+    }
+
+  puts ("ch done");
+}
+
+
+static void *
+tf1 (void *p)
+{
+  int err;
+
+  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
+      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+    {
+      puts ("cannot set cancellation options");
+      exit (1);
+    }
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    {
+      puts ("child: cannot get mutex");
+      exit (1);
+    }
+
+  err = pthread_barrier_wait (&bar);
+  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      printf ("barrier_wait returned %d\n", err);
+      exit (1);
+    }
+
+  puts ("child: got mutex; waiting");
+
+  pthread_cleanup_push (ch, NULL);
+
+  pthread_cond_wait (&cond, &mut);
+
+  pthread_cleanup_pop (0);
+
+  puts ("child: cond_wait should not have returned");
+
+  return NULL;
+}
+
+
+static void *
+tf2 (void *p)
+{
+  int err;
+
+  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
+      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
+    {
+      puts ("cannot set cancellation options");
+      exit (1);
+    }
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    {
+      puts ("child: cannot get mutex");
+      exit (1);
+    }
+
+  err = pthread_barrier_wait (&bar);
+  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      printf ("barrier_wait returned %d\n", err);
+      exit (1);
+    }
+
+  puts ("child: got mutex; waiting");
+
+  pthread_cleanup_push (ch, NULL);
+
+  /* Current time.  */
+  struct timeval tv;
+  (void) gettimeofday (&tv, NULL);
+  /* +1000 seconds in correct format.  */
+  struct timespec ts;
+  TIMEVAL_TO_TIMESPEC (&tv, &ts);
+  ts.tv_sec += 1000;
+
+  pthread_cond_timedwait (&cond, &mut, &ts);
+
+  pthread_cleanup_pop (0);
+
+  puts ("child: cond_wait should not have returned");
+
+  return NULL;
+}
+
+
+static int
+do_test (void)
+{
+  pthread_t th;
+  int err;
+
+  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+
+  puts ("parent: get mutex");
+
+  err = pthread_barrier_init (&bar, NULL, 2);
+  if (err != 0)
+    {
+      puts ("parent: cannot init barrier");
+      exit (1);
+    }
+
+  puts ("parent: create child");
+
+  err = pthread_create (&th, NULL, tf1, NULL);
+  if (err != 0)
+    {
+      puts ("parent: cannot create thread");
+      exit (1);
+    }
+
+  puts ("parent: wait for child to lock mutex");
+
+  err = pthread_barrier_wait (&bar);
+  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("parent: cannot wait for barrier");
+      exit (1);
+    }
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    {
+      puts ("parent: mutex_lock failed");
+      exit (1);
+    }
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    {
+      puts ("parent: mutex_unlock failed");
+      exit (1);
+    }
+
+  if (pthread_cancel (th) != 0)
+    {
+      puts ("cannot cancel thread");
+      exit (1);
+    }
+
+  void *r;
+  err = pthread_join (th, &r);
+  if (err != 0)
+    {
+      puts ("parent: failed to join");
+      exit (1);
+    }
+
+  if (r != PTHREAD_CANCELED)
+    {
+      puts ("child hasn't been canceled");
+      exit (1);
+    }
+
+
+
+  puts ("parent: create 2nd child");
+
+  err = pthread_create (&th, NULL, tf2, NULL);
+  if (err != 0)
+    {
+      puts ("parent: cannot create thread");
+      exit (1);
+    }
+
+  puts ("parent: wait for child to lock mutex");
+
+  err = pthread_barrier_wait (&bar);
+  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
+    {
+      puts ("parent: cannot wait for barrier");
+      exit (1);
+    }
+
+  err = pthread_mutex_lock (&mut);
+  if (err != 0)
+    {
+      puts ("parent: mutex_lock failed");
+      exit (1);
+    }
+
+  err = pthread_mutex_unlock (&mut);
+  if (err != 0)
+    {
+      puts ("parent: mutex_unlock failed");
+      exit (1);
+    }
+
+  if (pthread_cancel (th) != 0)
+    {
+      puts ("cannot cancel thread");
+      exit (1);
+    }
+
+  err = pthread_join (th, &r);
+  if (err != 0)
+    {
+      puts ("parent: failed to join");
+      exit (1);
+    }
+
+  if (r != PTHREAD_CANCELED)
+    {
+      puts ("child hasn't been canceled");
+      exit (1);
+    }
+
+  puts ("done");
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -23,254 +23,218 @@
 #include <time.h>
 #include <sys/time.h>
 
-
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 
 static pthread_barrier_t bar;
 
-
-static void
-ch (void *arg)
+static void ch(void *arg)
 {
-  int e = pthread_mutex_lock (&mut);
-  if (e == 0)
-    {
-      puts ("mutex not locked at all by cond_wait");
-      exit (1);
-    }
+	int e = pthread_mutex_lock(&mut);
+	if (e == 0) {
+		puts("mutex not locked at all by cond_wait");
+		exit(1);
+	}
 
-  if (e != EDEADLK)
-    {
-      puts ("no deadlock error signaled");
-      exit (1);
-    }
+	if (e != EDEADLK) {
+		puts("no deadlock error signaled");
+		exit(1);
+	}
 
-  if (pthread_mutex_unlock (&mut) != 0)
-    {
-      puts ("ch: cannot unlock mutex");
-      exit (1);
-    }
+	if (pthread_mutex_unlock(&mut) != 0) {
+		puts("ch: cannot unlock mutex");
+		exit(1);
+	}
 
-  puts ("ch done");
+	puts("ch done");
 }
 
-
-static void *
-tf1 (void *p)
+static void *tf1(void *p)
 {
-  int err;
+	int err;
 
-  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
-      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-    {
-      puts ("cannot set cancellation options");
-      exit (1);
-    }
+	if (pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0
+	    || pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0) {
+		puts("cannot set cancellation options");
+		exit(1);
+	}
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    {
-      puts ("child: cannot get mutex");
-      exit (1);
-    }
+	err = pthread_mutex_lock(&mut);
+	if (err != 0) {
+		puts("child: cannot get mutex");
+		exit(1);
+	}
 
-  err = pthread_barrier_wait (&bar);
-  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      printf ("barrier_wait returned %d\n", err);
-      exit (1);
-    }
+	err = pthread_barrier_wait(&bar);
+	if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+		printf("barrier_wait returned %d\n", err);
+		exit(1);
+	}
 
-  puts ("child: got mutex; waiting");
+	puts("child: got mutex; waiting");
 
-  pthread_cleanup_push (ch, NULL);
+	pthread_cleanup_push(ch, NULL);
 
-  pthread_cond_wait (&cond, &mut);
+	pthread_cond_wait(&cond, &mut);
 
-  pthread_cleanup_pop (0);
+	pthread_cleanup_pop(0);
 
-  puts ("child: cond_wait should not have returned");
+	puts("child: cond_wait should not have returned");
 
-  return NULL;
+	return NULL;
 }
 
-
-static void *
-tf2 (void *p)
+static void *tf2(void *p)
 {
-  int err;
+	int err;
 
-  if (pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL) != 0
-      || pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-    {
-      puts ("cannot set cancellation options");
-      exit (1);
-    }
+	if (pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0
+	    || pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0) {
+		puts("cannot set cancellation options");
+		exit(1);
+	}
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    {
-      puts ("child: cannot get mutex");
-      exit (1);
-    }
+	err = pthread_mutex_lock(&mut);
+	if (err != 0) {
+		puts("child: cannot get mutex");
+		exit(1);
+	}
 
-  err = pthread_barrier_wait (&bar);
-  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      printf ("barrier_wait returned %d\n", err);
-      exit (1);
-    }
+	err = pthread_barrier_wait(&bar);
+	if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+		printf("barrier_wait returned %d\n", err);
+		exit(1);
+	}
 
-  puts ("child: got mutex; waiting");
+	puts("child: got mutex; waiting");
 
-  pthread_cleanup_push (ch, NULL);
+	pthread_cleanup_push(ch, NULL);
 
-  /* Current time.  */
-  struct timeval tv;
-  (void) gettimeofday (&tv, NULL);
-  /* +1000 seconds in correct format.  */
-  struct timespec ts;
-  TIMEVAL_TO_TIMESPEC (&tv, &ts);
-  ts.tv_sec += 1000;
+	/* Current time.  */
+	struct timeval tv;
+	(void)gettimeofday(&tv, NULL);
+	/* +1000 seconds in correct format.  */
+	struct timespec ts;
+	TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	ts.tv_sec += 1000;
 
-  pthread_cond_timedwait (&cond, &mut, &ts);
+	pthread_cond_timedwait(&cond, &mut, &ts);
 
-  pthread_cleanup_pop (0);
+	pthread_cleanup_pop(0);
 
-  puts ("child: cond_wait should not have returned");
+	puts("child: cond_wait should not have returned");
 
-  return NULL;
+	return NULL;
 }
 
-
-static int
-do_test (void)
+static int do_test(void)
 {
-  pthread_t th;
-  int err;
+	pthread_t th;
+	int err;
 
-  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+	printf("&cond = %p\n&mut = %p\n", &cond, &mut);
 
-  puts ("parent: get mutex");
+	puts("parent: get mutex");
 
-  err = pthread_barrier_init (&bar, NULL, 2);
-  if (err != 0)
-    {
-      puts ("parent: cannot init barrier");
-      exit (1);
-    }
+	err = pthread_barrier_init(&bar, NULL, 2);
+	if (err != 0) {
+		puts("parent: cannot init barrier");
+		exit(1);
+	}
 
-  puts ("parent: create child");
+	puts("parent: create child");
 
-  err = pthread_create (&th, NULL, tf1, NULL);
-  if (err != 0)
-    {
-      puts ("parent: cannot create thread");
-      exit (1);
-    }
+	err = pthread_create(&th, NULL, tf1, NULL);
+	if (err != 0) {
+		puts("parent: cannot create thread");
+		exit(1);
+	}
 
-  puts ("parent: wait for child to lock mutex");
+	puts("parent: wait for child to lock mutex");
 
-  err = pthread_barrier_wait (&bar);
-  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("parent: cannot wait for barrier");
-      exit (1);
-    }
+	err = pthread_barrier_wait(&bar);
+	if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("parent: cannot wait for barrier");
+		exit(1);
+	}
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    {
-      puts ("parent: mutex_lock failed");
-      exit (1);
-    }
+	err = pthread_mutex_lock(&mut);
+	if (err != 0) {
+		puts("parent: mutex_lock failed");
+		exit(1);
+	}
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    {
-      puts ("parent: mutex_unlock failed");
-      exit (1);
-    }
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0) {
+		puts("parent: mutex_unlock failed");
+		exit(1);
+	}
 
-  if (pthread_cancel (th) != 0)
-    {
-      puts ("cannot cancel thread");
-      exit (1);
-    }
+	if (pthread_cancel(th) != 0) {
+		puts("cannot cancel thread");
+		exit(1);
+	}
 
-  void *r;
-  err = pthread_join (th, &r);
-  if (err != 0)
-    {
-      puts ("parent: failed to join");
-      exit (1);
-    }
+	void *r;
+	err = pthread_join(th, &r);
+	if (err != 0) {
+		puts("parent: failed to join");
+		exit(1);
+	}
 
-  if (r != PTHREAD_CANCELED)
-    {
-      puts ("child hasn't been canceled");
-      exit (1);
-    }
+	if (r != PTHREAD_CANCELED) {
+		puts("child hasn't been canceled");
+		exit(1);
+	}
 
+	puts("parent: create 2nd child");
 
+	err = pthread_create(&th, NULL, tf2, NULL);
+	if (err != 0) {
+		puts("parent: cannot create thread");
+		exit(1);
+	}
 
-  puts ("parent: create 2nd child");
+	puts("parent: wait for child to lock mutex");
 
-  err = pthread_create (&th, NULL, tf2, NULL);
-  if (err != 0)
-    {
-      puts ("parent: cannot create thread");
-      exit (1);
-    }
+	err = pthread_barrier_wait(&bar);
+	if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD) {
+		puts("parent: cannot wait for barrier");
+		exit(1);
+	}
 
-  puts ("parent: wait for child to lock mutex");
+	err = pthread_mutex_lock(&mut);
+	if (err != 0) {
+		puts("parent: mutex_lock failed");
+		exit(1);
+	}
 
-  err = pthread_barrier_wait (&bar);
-  if (err != 0 && err != PTHREAD_BARRIER_SERIAL_THREAD)
-    {
-      puts ("parent: cannot wait for barrier");
-      exit (1);
-    }
+	err = pthread_mutex_unlock(&mut);
+	if (err != 0) {
+		puts("parent: mutex_unlock failed");
+		exit(1);
+	}
 
-  err = pthread_mutex_lock (&mut);
-  if (err != 0)
-    {
-      puts ("parent: mutex_lock failed");
-      exit (1);
-    }
+	if (pthread_cancel(th) != 0) {
+		puts("cannot cancel thread");
+		exit(1);
+	}
 
-  err = pthread_mutex_unlock (&mut);
-  if (err != 0)
-    {
-      puts ("parent: mutex_unlock failed");
-      exit (1);
-    }
+	err = pthread_join(th, &r);
+	if (err != 0) {
+		puts("parent: failed to join");
+		exit(1);
+	}
 
-  if (pthread_cancel (th) != 0)
-    {
-      puts ("cannot cancel thread");
-      exit (1);
-    }
+	if (r != PTHREAD_CANCELED) {
+		puts("child hasn't been canceled");
+		exit(1);
+	}
 
-  err = pthread_join (th, &r);
-  if (err != 0)
-    {
-      puts ("parent: failed to join");
-      exit (1);
-    }
+	puts("done");
 
-  if (r != PTHREAD_CANCELED)
-    {
-      puts ("child hasn't been canceled");
-      exit (1);
-    }
-
-  puts ("done");
-
-  return 0;
+	return 0;
 }
-
 
 #define TEST_FUNCTION do_test ()
 #include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -236,5 +236,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -1,0 +1,149 @@
+/* Copyright (C) 2003-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@redhat.com>, 2003.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
+
+
+static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+
+
+static void *
+tf (void *arg)
+{
+  int err = pthread_cond_wait (&cond, &mut);
+  if (err == 0)
+    {
+      puts ("cond_wait did not fail");
+      exit (1);
+    }
+
+  if (err != EPERM)
+    {
+      printf ("cond_wait didn't return EPERM but %d\n", err);
+      exit (1);
+    }
+
+
+  /* Current time.  */
+  struct timeval tv;
+  (void) gettimeofday (&tv, NULL);
+  /* +1000 seconds in correct format.  */
+  struct timespec ts;
+  TIMEVAL_TO_TIMESPEC (&tv, &ts);
+  ts.tv_sec += 1000;
+
+  err = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (err == 0)
+    {
+      puts ("cond_timedwait did not fail");
+      exit (1);
+    }
+
+  if (err != EPERM)
+    {
+      printf ("cond_timedwait didn't return EPERM but %d\n", err);
+      exit (1);
+    }
+
+  return (void *) 1l;
+}
+
+
+static int
+do_test (void)
+{
+  pthread_t th;
+  int err;
+
+  printf ("&cond = %p\n&mut = %p\n", &cond, &mut);
+
+  err = pthread_cond_wait (&cond, &mut);
+  if (err == 0)
+    {
+      puts ("cond_wait did not fail");
+      exit (1);
+    }
+
+  if (err != EPERM)
+    {
+      printf ("cond_wait didn't return EPERM but %d\n", err);
+      exit (1);
+    }
+
+
+  /* Current time.  */
+  struct timeval tv;
+  (void) gettimeofday (&tv, NULL);
+  /* +1000 seconds in correct format.  */
+  struct timespec ts;
+  TIMEVAL_TO_TIMESPEC (&tv, &ts);
+  ts.tv_sec += 1000;
+
+  err = pthread_cond_timedwait (&cond, &mut, &ts);
+  if (err == 0)
+    {
+      puts ("cond_timedwait did not fail");
+      exit (1);
+    }
+
+  if (err != EPERM)
+    {
+      printf ("cond_timedwait didn't return EPERM but %d\n", err);
+      exit (1);
+    }
+
+  if (pthread_mutex_lock (&mut) != 0)
+    {
+      puts ("parent: mutex_lock failed");
+      exit (1);
+    }
+
+  puts ("creating thread");
+
+  if (pthread_create (&th, NULL, tf, NULL) != 0)
+    {
+      puts ("create failed");
+      exit (1);
+    }
+
+  void *r;
+  if (pthread_join (th, &r) != 0)
+    {
+      puts ("join failed");
+      exit (1);
+    }
+  if (r != (void *) 1l)
+    {
+      puts ("thread has wrong return value");
+      exit (1);
+    }
+
+  puts ("done");
+
+  return 0;
+}
+
+
+#define TEST_FUNCTION do_test ()
+#include "../test-skeleton.c"

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -125,5 +125,4 @@ static int do_test(void)
 	return 0;
 }
 
-#define TEST_FUNCTION do_test ()
-#include "../test-skeleton.c"
+#include "test-driver.c"

--- a/tools/Lindent
+++ b/tools/Lindent
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+
+PARAM="-npro -kr -i8 -ts8 -sob -l80 -ss -ncs -cp1"
+
+RES=`indent --version | cut -d' ' -f3`
+if [ "$RES" = "" ]; then
+	exit 1
+fi
+V1=`echo $RES | cut -d'.' -f1`
+V2=`echo $RES | cut -d'.' -f2`
+V3=`echo $RES | cut -d'.' -f3`
+
+if [ $V1 -gt 2 ]; then
+  PARAM="$PARAM -il0"
+elif [ $V1 -eq 2 ]; then
+  if [ $V2 -gt 2 ]; then
+    PARAM="$PARAM -il0"
+  elif [ $V2 -eq 2 ]; then
+    if [ $V3 -ge 10 ]; then
+      PARAM="$PARAM -il0"
+    fi
+  fi
+fi
+
+indent $PARAM "$@"


### PR DESCRIPTION
This change set adds 20+ condvar tests imported from glibc, cleans-up the coding style to match the rest of the library and make them readable by humans, adds a basic test driver which is a stripped down version of the one available in glibc and converts the imported tests to the new test driver. This is done in preparation to converting these tests to the librtpi API in a future change set.