### PR TITLE
[PATCH v2] Bulk convert glibc tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,15 @@ condition variable.
 #### int pi_cond_broadcast(pi_cond_t \*cond)
 
 ## Initializers
-No initializers will be provided as the parallel glibc implementation requires
-the use of attrs to setup the protocol and clock at a minimum. RTPI also
-requires a known mutex to be associated with a condition variable at the time of
-initialization.
+
+#### DEFINE_PI_MUTEX(mutex, flags)
+
+Defines and initializes a PI aware mutex.
+
+#### DEFINE_PI_COND(condvar, mutex, flags)
+
+Defines and initializes a PI aware conditional variable. The mutex is
+associated with the conditional variable at this time.
 
 # C++ Specification
 WRITEME - after the C Specification is complete

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 
 lib_LTLIBRARIES = librtpi.la
-librtpi_la_SOURCES = rtpi_internal.h pi_futex.h pi_mutex.c pi_cond.c
-include_HEADERS = rtpi.h
+librtpi_la_SOURCES = pi_futex.h pi_mutex.c pi_cond.c
+include_HEADERS = rtpi.h rtpi_internal.h

--- a/src/pi_cond.c
+++ b/src/pi_cond.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
-#include "rtpi_internal.h"
+#include "rtpi.h"
 #include "pi_futex.h"
 
 /*
@@ -24,7 +24,7 @@ void pi_cond_free(pi_cond_t *cond)
 	free(cond);
 }
 
-int pi_cond_init(pi_cond_t *cond, struct pi_mutex *mutex, uint32_t flags)
+int pi_cond_init(pi_cond_t *cond, pi_mutex_t *mutex, uint32_t flags)
 {
 	struct timespec ts = { 0, 0 };
 	int ret;

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 // Copyright © 2018 VMware, Inc. All Rights Reserved.
 
-#include "rtpi_internal.h"
+#include "rtpi.h"
 #include "pi_futex.h"
 #include <stdbool.h>
 #include <string.h>

--- a/src/rtpi.h
+++ b/src/rtpi.h
@@ -10,12 +10,16 @@
 #include <stdlib.h>
 #include <time.h>
 
-typedef struct pi_mutex pi_mutex_t;
-typedef struct pi_cond pi_cond_t;
+#include "rtpi_internal.h"
+
+typedef union pi_mutex pi_mutex_t;
+typedef union pi_cond pi_cond_t;
 
 /*
  * PI Mutex Interface
  */
+#define DEFINE_PI_MUTEX(mutex, flags) \
+	pi_mutex_t mutex = PI_MUTEX_INIT(flags)
 
 #define RTPI_MUTEX_PSHARED    0x1
 //#define RTPI_MUTEX_ROBUST     0x2
@@ -39,6 +43,8 @@ int pi_mutex_unlock(pi_mutex_t *mutex);
 /*
  * PI Cond Interface
  */
+#define DEFINE_PI_COND(condvar, mutex, flags) \
+	pi_cond_t condvar = PI_COND_INIT(mutex, flags)
 
 #define RTPI_COND_PSHARED     RTPI_MUTEX_PSHARED
 

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -1,4 +1,4 @@
-/* Verify that exception table for pthread_cond_wait is correct.
+/* Verify that exception table for pi_cond_wait is correct.
    Copyright (C) 2012-2019 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
@@ -22,8 +22,8 @@
 #include <string.h>
 #include <unistd.h>
 
-pthread_mutex_t mutex;
-pthread_cond_t cond;
+pi_mutex_t mutex;
+pi_cond_t cond;
 
 #define CHECK_RETURN_VAL_OR_FAIL(ret,str) \
   ({ if ((ret) != 0) \
@@ -37,7 +37,7 @@ pthread_cond_t cond;
 void clean(void *arg)
 {
 	puts("clean: Unlocking mutex...");
-	pthread_mutex_unlock((pthread_mutex_t *) arg);
+	pi_mutex_unlock((pi_mutex_t *) arg);
 	puts("clean: Mutex unlocked...");
 }
 
@@ -51,20 +51,20 @@ void *thr(void *arg)
 	ret = pthread_mutexattr_setprotocol(&mutexAttr, PTHREAD_PRIO_INHERIT);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutexattr_setprotocol");
 
-	ret = pthread_mutex_init(&mutex, &mutexAttr);
-	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutex_init");
+	ret = pi_mutex_init(&mutex, &mutexAttr);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_mutex_init");
 
-	ret = pthread_cond_init(&cond, 0);
-	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_cond_init");
+	ret = pi_cond_init(&cond, 0);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_cond_init");
 
 	puts("th: Init done, entering wait...");
 
 	pthread_cleanup_push(clean, (void *)&mutex);
-	ret = pthread_mutex_lock(&mutex);
-	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutex_lock");
+	ret = pi_mutex_lock(&mutex);
+	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_mutex_lock");
 	while (1) {
-		ret = pthread_cond_wait(&cond, &mutex);
-		CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_cond_wait");
+		ret = pi_cond_wait(&cond);
+		CHECK_RETURN_VAL_OR_FAIL(ret, "pi_cond_wait");
 	}
 	pthread_cleanup_pop(1);
 

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "rtpi.h"
+
 pi_mutex_t mutex;
 pi_cond_t cond;
 
@@ -44,17 +46,11 @@ void clean(void *arg)
 void *thr(void *arg)
 {
 	int ret = 0;
-	pthread_mutexattr_t mutexAttr;
-	ret = pthread_mutexattr_init(&mutexAttr);
-	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutexattr_init");
 
-	ret = pthread_mutexattr_setprotocol(&mutexAttr, PTHREAD_PRIO_INHERIT);
-	CHECK_RETURN_VAL_OR_FAIL(ret, "pthread_mutexattr_setprotocol");
-
-	ret = pi_mutex_init(&mutex, &mutexAttr);
+	ret = pi_mutex_init(&mutex, 0);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_mutex_init");
 
-	ret = pi_cond_init(&cond, 0);
+	ret = pi_cond_init(&cond, &mutex, 0);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_cond_init");
 
 	puts("th: Init done, entering wait...");

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -20,9 +20,10 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "rtpi.h"
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 
 static void *tf(void *p)
 {

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -21,24 +21,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 
 static void *tf(void *p)
 {
 	int err;
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "child: cannot get mutex");
 
 	puts("child: got mutex; signalling");
 
-	pthread_cond_signal(&cond);
+	pi_cond_signal(&cond);
 
 	puts("child: unlock");
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "child: cannot unlock");
 
@@ -56,7 +56,7 @@ static int do_test(void)
 
 	puts("parent: get mutex");
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "parent: cannot get mutex");
 
@@ -71,7 +71,7 @@ static int do_test(void)
 	/* This test will fail on spurious wake-ups, which are allowed; however,
 	   the current implementation shouldn't produce spurious wake-ups in the
 	   scenario we are testing here.  */
-	err = pthread_cond_wait(&cond, &mut);
+	err = pi_cond_wait(&cond);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "parent: cannot wait fir signal");
 

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -25,14 +25,14 @@
 #define N 10
 #define ROUNDS 100
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 static pthread_barrier_t bN1;
 static pthread_barrier_t b2;
 
 static void *tf(void *p)
 {
-	if (pthread_mutex_lock(&mut) != 0) {
+	if (pi_mutex_lock(&mut) != 0) {
 		puts("child: 1st mutex_lock failed");
 		exit(1);
 	}
@@ -43,12 +43,12 @@ static void *tf(void *p)
 		exit(1);
 	}
 
-	if (pthread_cond_wait(&cond, &mut) != 0) {
+	if (pi_cond_wait(&cond) != 0) {
 		puts("child: cond_wait failed");
 		exit(1);
 	}
 
-	if (pthread_mutex_unlock(&mut) != 0) {
+	if (pi_mutex_unlock(&mut) != 0) {
 		puts("child: mutex_unlock failed");
 		exit(1);
 	}
@@ -105,11 +105,11 @@ static int do_test(void)
 			}
 		}
 
-		if (pthread_mutex_lock(&mut) != 0) {
+		if (pi_mutex_lock(&mut) != 0) {
 			puts("parent: mutex_lock failed");
 			exit(1);
 		}
-		if (pthread_mutex_unlock(&mut) != 0) {
+		if (pi_mutex_unlock(&mut) != 0) {
 			puts("parent: mutex_unlock failed");
 			exit(1);
 		}
@@ -117,7 +117,7 @@ static int do_test(void)
 		/* N single signal calls.  Without locking.  This tests that no
 		   signal gets lost.  */
 		for (i = 0; i < N; ++i)
-			if (pthread_cond_signal(&cond) != 0) {
+			if (pi_cond_signal(&cond) != 0) {
 				puts("cond_signal failed");
 				exit(1);
 			}

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -22,11 +22,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "rtpi.h"
+
 #define N 10
 #define ROUNDS 100
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 static pthread_barrier_t bN1;
 static pthread_barrier_t b2;
 

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -22,65 +22,33 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "rtpi.h"
+
 #if defined _POSIX_CLOCK_SELECTION && _POSIX_CLOCK_SELECTION >= 0
 static int run_test(clockid_t cl)
 {
-	pthread_condattr_t condattr;
 	pi_cond_t cond;
-	pthread_mutexattr_t mutattr;
 	pi_mutex_t mut;
+	uint32_t flags = 0;
 
 	printf("clock = %d\n", (int)cl);
 
-	if (pthread_condattr_init(&condattr) != 0) {
-		puts("condattr_init failed");
+	if (cl == CLOCK_REALTIME) {
+#ifdef RTPI_COND_CLOCK_REALTIME
+		flags = RTPI_COND_CLOCK_REALTIME;
+#else
+		puts("CLOCK_REALTIME not supported");
 		return 1;
+#endif
 	}
 
-	if (pthread_condattr_setclock(&condattr, cl) != 0) {
-		puts("condattr_setclock failed");
-		return 1;
-	}
-
-	clockid_t cl2;
-	if (pthread_condattr_getclock(&condattr, &cl2) != 0) {
-		puts("condattr_getclock failed");
-		return 1;
-	}
-	if (cl != cl2) {
-		printf
-		    ("condattr_getclock returned wrong value: %d, expected %d\n",
-		     (int)cl2, (int)cl);
-		return 1;
-	}
-
-	if (pi_cond_init(&cond, &condattr) != 0) {
-		puts("cond_init failed");
-		return 1;
-	}
-
-	if (pthread_condattr_destroy(&condattr) != 0) {
-		puts("condattr_destroy failed");
-		return 1;
-	}
-
-	if (pthread_mutexattr_init(&mutattr) != 0) {
-		puts("mutexattr_init failed");
-		return 1;
-	}
-
-	if (pthread_mutexattr_settype(&mutattr, PTHREAD_MUTEX_ERRORCHECK) != 0) {
-		puts("mutexattr_settype failed");
-		return 1;
-	}
-
-	if (pi_mutex_init(&mut, &mutattr) != 0) {
+	if (pi_mutex_init(&mut, 0) != 0) {
 		puts("mutex_init failed");
 		return 1;
 	}
 
-	if (pthread_mutexattr_destroy(&mutattr) != 0) {
-		puts("mutexattr_destroy failed");
+	if (pi_cond_init(&cond, &mut, flags) != 0) {
+		puts("cond_init failed");
 		return 1;
 	}
 

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -26,9 +26,9 @@
 static int run_test(clockid_t cl)
 {
 	pthread_condattr_t condattr;
-	pthread_cond_t cond;
+	pi_cond_t cond;
 	pthread_mutexattr_t mutattr;
-	pthread_mutex_t mut;
+	pi_mutex_t mut;
 
 	printf("clock = %d\n", (int)cl);
 
@@ -54,7 +54,7 @@ static int run_test(clockid_t cl)
 		return 1;
 	}
 
-	if (pthread_cond_init(&cond, &condattr) != 0) {
+	if (pi_cond_init(&cond, &condattr) != 0) {
 		puts("cond_init failed");
 		return 1;
 	}
@@ -74,7 +74,7 @@ static int run_test(clockid_t cl)
 		return 1;
 	}
 
-	if (pthread_mutex_init(&mut, &mutattr) != 0) {
+	if (pi_mutex_init(&mut, &mutattr) != 0) {
 		puts("mutex_init failed");
 		return 1;
 	}
@@ -84,12 +84,12 @@ static int run_test(clockid_t cl)
 		return 1;
 	}
 
-	if (pthread_mutex_lock(&mut) != 0) {
+	if (pi_mutex_lock(&mut) != 0) {
 		puts("mutex_lock failed");
 		return 1;
 	}
 
-	if (pthread_mutex_lock(&mut) != EDEADLK) {
+	if (pi_mutex_lock(&mut) != EDEADLK) {
 		puts("2nd mutex_lock did not return EDEADLK");
 		return 1;
 	}
@@ -103,7 +103,7 @@ static int run_test(clockid_t cl)
 	/* Wait one second.  */
 	++ts.tv_sec;
 
-	int e = pthread_cond_timedwait(&cond, &mut, &ts);
+	int e = pi_cond_timedwait(&cond, &ts);
 	if (e == 0) {
 		puts("cond_timedwait succeeded");
 		return 1;
@@ -124,17 +124,17 @@ static int run_test(clockid_t cl)
 		return 1;
 	}
 
-	if (pthread_mutex_unlock(&mut) != 0) {
+	if (pi_mutex_unlock(&mut) != 0) {
 		puts("mutex_unlock failed");
 		return 1;
 	}
 
-	if (pthread_mutex_destroy(&mut) != 0) {
+	if (pi_mutex_destroy(&mut) != 0) {
 		puts("mutex_destroy failed");
 		return 1;
 	}
 
-	if (pthread_cond_destroy(&cond) != 0) {
+	if (pi_cond_destroy(&cond) != 0) {
 		puts("cond_destroy failed");
 		return 1;
 	}

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -17,13 +17,14 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include <errno.h>
-#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/wait.h>
+
+#include "rtpi.h"
 
 static char fname[] = "/tmp/tst-cond12-XXXXXX";
 static int fd;
@@ -63,39 +64,13 @@ static int do_test(void)
 		return 1;
 	}
 
-	pthread_mutexattr_t ma;
-	if (pthread_mutexattr_init(&ma) != 0) {
-		puts("mutexattr_init failed");
-		return 1;
-	}
-	if (pthread_mutexattr_setpshared(&ma, 1) != 0) {
-		puts("mutexattr_setpshared failed");
-		return 1;
-	}
-	if (pi_mutex_init(&p->m, &ma) != 0) {
+	if (pi_mutex_init(&p->m, RTPI_MUTEX_PSHARED) != 0) {
 		puts("mutex_init failed");
-		return 1;
-	}
-	if (pthread_mutexattr_destroy(&ma) != 0) {
-		puts("mutexattr_destroy failed");
 		return 1;
 	}
 
-	pthread_condattr_t ca;
-	if (pthread_condattr_init(&ca) != 0) {
-		puts("condattr_init failed");
-		return 1;
-	}
-	if (pthread_condattr_setpshared(&ca, 1) != 0) {
-		puts("condattr_setpshared failed");
-		return 1;
-	}
-	if (pi_cond_init(&p->c, &ca) != 0) {
+	if (pi_cond_init(&p->c, &p->m, RTPI_COND_PSHARED) != 0) {
 		puts("mutex_init failed");
-		return 1;
-	}
-	if (pthread_condattr_destroy(&ca) != 0) {
-		puts("condattr_destroy failed");
 		return 1;
 	}
 

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -53,8 +53,8 @@ static void prepare(void)
 static int do_test(void)
 {
 	struct {
-		pthread_mutex_t m;
-		pthread_cond_t c;
+		pi_mutex_t m;
+		pi_cond_t c;
 		int var;
 	} *p =
 	    mmap(NULL, sizeof(*p), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
@@ -72,7 +72,7 @@ static int do_test(void)
 		puts("mutexattr_setpshared failed");
 		return 1;
 	}
-	if (pthread_mutex_init(&p->m, &ma) != 0) {
+	if (pi_mutex_init(&p->m, &ma) != 0) {
 		puts("mutex_init failed");
 		return 1;
 	}
@@ -90,7 +90,7 @@ static int do_test(void)
 		puts("condattr_setpshared failed");
 		return 1;
 	}
-	if (pthread_cond_init(&p->c, &ca) != 0) {
+	if (pi_cond_init(&p->c, &ca) != 0) {
 		puts("mutex_init failed");
 		return 1;
 	}
@@ -99,7 +99,7 @@ static int do_test(void)
 		return 1;
 	}
 
-	if (pthread_mutex_lock(&p->m) != 0) {
+	if (pi_mutex_lock(&p->m) != 0) {
 		puts("initial mutex_lock failed");
 		return 1;
 	}
@@ -125,7 +125,7 @@ static int do_test(void)
 
 		munmap(oldp, sizeof(*p));
 
-		if (pthread_mutex_lock(&p->m) != 0) {
+		if (pi_mutex_lock(&p->m) != 0) {
 			puts("child: mutex_lock failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
@@ -134,20 +134,20 @@ static int do_test(void)
 		p->var = 0;
 
 #ifndef USE_COND_SIGNAL
-		if (pthread_cond_broadcast(&p->c) != 0) {
+		if (pi_cond_broadcast(&p->c) != 0) {
 			puts("child: cond_broadcast failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
 		}
 #else
-		if (pthread_cond_signal(&p->c) != 0) {
+		if (pi_cond_signal(&p->c) != 0) {
 			puts("child: cond_signal failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
 		}
 #endif
 
-		if (pthread_mutex_unlock(&p->m) != 0) {
+		if (pi_mutex_unlock(&p->m) != 0) {
 			puts("child: mutex_unlock failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
@@ -157,7 +157,7 @@ static int do_test(void)
 	}
 
 	do
-		pthread_cond_wait(&p->c, &p->m);
+		pi_cond_wait(&p->c);
 	while (p->var != 0);
 
 	if (TEMP_FAILURE_RETRY(waitpid(pid, NULL, 0)) != pid) {

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -24,8 +24,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-pi_cond_t cv = PTHREAD_COND_INITIALIZER;
-pi_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+#include "rtpi.h"
+
+DEFINE_PI_MUTEX(lock, 0);
+DEFINE_PI_COND(cv, &lock, 0);
 bool n, exiting;
 FILE *f;
 enum { count = 8 };		/* Number of worker threads.  */

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -24,8 +24,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-pthread_cond_t cv = PTHREAD_COND_INITIALIZER;
-pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+pi_cond_t cv = PTHREAD_COND_INITIALIZER;
+pi_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 bool n, exiting;
 FILE *f;
 enum { count = 8 };		/* Number of worker threads.  */
@@ -35,24 +35,24 @@ void *tf(void *dummy)
 	bool loop = true;
 
 	while (loop) {
-		pthread_mutex_lock(&lock);
+		pi_mutex_lock(&lock);
 		while (n && !exiting)
-			pthread_cond_wait(&cv, &lock);
+			pi_cond_wait(&cv);
 		n = true;
-		pthread_mutex_unlock(&lock);
+		pi_mutex_unlock(&lock);
 
 		fputs(".", f);
 
-		pthread_mutex_lock(&lock);
+		pi_mutex_lock(&lock);
 		n = false;
 		if (exiting)
 			loop = false;
 #ifdef UNLOCK_AFTER_BROADCAST
-		pthread_cond_broadcast(&cv);
-		pthread_mutex_unlock(&lock);
+		pi_cond_broadcast(&cv);
+		pi_mutex_unlock(&lock);
 #else
-		pthread_mutex_unlock(&lock);
-		pthread_cond_broadcast(&cv);
+		pi_mutex_unlock(&lock);
+		pi_cond_broadcast(&cv);
 #endif
 	}
 
@@ -85,9 +85,9 @@ int do_test(void)
 	struct timespec ts = {.tv_sec = 20,.tv_nsec = 0 };
 	while (nanosleep(&ts, &ts) != 0) ;
 
-	pthread_mutex_lock(&lock);
+	pi_mutex_lock(&lock);
 	exiting = true;
-	pthread_mutex_unlock(&lock);
+	pi_mutex_unlock(&lock);
 
 	for (i = 0; i < count; ++i)
 		pthread_join(th[i], NULL);

--- a/tests/glibc-tests/tst-cond18.c
+++ b/tests/glibc-tests/tst-cond18.c
@@ -25,8 +25,10 @@
 #include <stdio.h>
 #include <unistd.h>
 
-pi_cond_t cv = PTHREAD_COND_INITIALIZER;
-pi_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+#include "rtpi.h"
+
+DEFINE_PI_MUTEX(lock, 0);
+DEFINE_PI_COND(cv, &lock, 0);
 bool exiting;
 int fd, spins, nn;
 enum { count = 8 };		/* Number of worker threads.  */

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -22,8 +22,8 @@
 #include <stdlib.h>
 #include <time.h>
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 
 static int do_test(void)
 {
@@ -37,7 +37,7 @@ static int do_test(void)
 
 	ts.tv_nsec = -1;
 
-	int e = pthread_cond_timedwait(&cond, &mut, &ts);
+	int e = pi_cond_timedwait(&cond, &ts);
 	if (e == 0) {
 		puts("first cond_timedwait did not fail");
 		result = 1;
@@ -48,7 +48,7 @@ static int do_test(void)
 
 	ts.tv_nsec = 2000000000;
 
-	e = pthread_cond_timedwait(&cond, &mut, &ts);
+	e = pi_cond_timedwait(&cond, &ts);
 	if (e == 0) {
 		puts("second cond_timedwait did not fail");
 		result = 1;

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -22,8 +22,10 @@
 #include <stdlib.h>
 #include <time.h>
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+#include "rtpi.h"
+
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 
 static int do_test(void)
 {

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -20,10 +20,10 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "rtpi.h"
 
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 static pthread_barrier_t bar;
 
 static void *tf(void *a)

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -21,8 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
 
 static pthread_barrier_t bar;
 
@@ -33,7 +33,7 @@ static void *tf(void *a)
 
 	printf("child %d: lock\n", i);
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "locking in child failed");
 
@@ -47,13 +47,13 @@ static void *tf(void *a)
 
 	printf("child %d: wait\n", i);
 
-	err = pthread_cond_wait(&cond, &mut);
+	err = pi_cond_wait(&cond);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "child %d: failed to wait", i);
 
 	printf("child %d: woken up\n", i);
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "child %d: unlock[2] failed", i);
 
@@ -114,18 +114,18 @@ static int do_test(void)
 
 	puts("get lock outselves");
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "mut locking failed");
 
 	puts("broadcast");
 
 	/* Wake up all threads.  */
-	err = pthread_cond_broadcast(&cond);
+	err = pi_cond_broadcast(&cond);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "parent: broadcast failed");
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "mut unlocking failed");
 

--- a/tests/glibc-tests/tst-cond20.c
+++ b/tests/glibc-tests/tst-cond20.c
@@ -22,11 +22,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "rtpi.h"
+
 #define N 10
 #define ROUNDS 1000
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_cond_t cond2 = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond2, &mut, 0);
 static pthread_barrier_t b;
 static int count;
 
@@ -136,7 +138,7 @@ static int do_test(void)
 		}
 
 		count = 0;
-		err = pi_cond_init(&cond, NULL);
+		err = pi_cond_init(&cond, &mut, 0);
 		if (err) {
 			printf("pi_cond_init failed: %s\n", strerror(err));
 			return 1;

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -3,17 +3,17 @@
 #include <stdlib.h>
 
 static pthread_barrier_t b;
-static pthread_cond_t c = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t c = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 
 static void cl(void *arg)
 {
-	pthread_mutex_unlock(&m);
+	pi_mutex_unlock(&m);
 }
 
 static void *tf(void *arg)
 {
-	if (pthread_mutex_lock(&m) != 0) {
+	if (pi_mutex_lock(&m) != 0) {
 		printf("%s: mutex_lock failed\n", __func__);
 		exit(1);
 	}
@@ -28,13 +28,13 @@ static void *tf(void *arg)
 	   on the mutex.  In this case the beginning of the second cond_wait
 	   call will cause the cancellation to happen.  */
 	do
-		if (pthread_cond_wait(&c, &m) != 0) {
+		if (pi_cond_wait(&c) != 0) {
 			printf("%s: cond_wait failed\n", __func__);
 			exit(1);
 		}
 	while (arg == NULL) ;
 	pthread_cleanup_pop(0);
-	if (pthread_mutex_unlock(&m) != 0) {
+	if (pi_mutex_unlock(&m) != 0) {
 		printf("%s: mutex_unlock failed\n", __func__);
 		exit(1);
 	}
@@ -60,11 +60,11 @@ static int do_test(void)
 		puts("1st barrier_wait failed");
 		return 1;
 	}
-	if (pthread_mutex_lock(&m) != 0) {
+	if (pi_mutex_lock(&m) != 0) {
 		puts("1st mutex_lock failed");
 		return 1;
 	}
-	if (pthread_cond_signal(&c) != 0) {
+	if (pi_cond_signal(&c) != 0) {
 		puts("1st cond_signal failed");
 		return 1;
 	}
@@ -72,7 +72,7 @@ static int do_test(void)
 		puts("cancel failed");
 		return 1;
 	}
-	if (pthread_mutex_unlock(&m) != 0) {
+	if (pi_mutex_unlock(&m) != 0) {
 		puts("1st mutex_unlock failed");
 		return 1;
 	}
@@ -102,15 +102,15 @@ static int do_test(void)
 		puts("2nd barrier_wait failed");
 		return 1;
 	}
-	if (pthread_mutex_lock(&m) != 0) {
+	if (pi_mutex_lock(&m) != 0) {
 		puts("2nd mutex_lock failed");
 		return 1;
 	}
-	if (pthread_cond_signal(&c) != 0) {
+	if (pi_cond_signal(&c) != 0) {
 		puts("2nd cond_signal failed");
 		return 1;
 	}
-	if (pthread_mutex_unlock(&m) != 0) {
+	if (pi_mutex_unlock(&m) != 0) {
 		puts("2nd mutex_unlock failed");
 		return 1;
 	}

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -2,9 +2,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "rtpi.h"
+
 static pthread_barrier_t b;
-static pi_cond_t c = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+static DEFINE_PI_MUTEX(m, 0);
+static DEFINE_PI_COND(c, &m, 0);
 
 static void cl(void *arg)
 {

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -30,9 +30,9 @@
 #define THREADS_NUM 5
 #define MAXITER 50000
 
-static pthread_mutex_t mutex;
+static pi_mutex_t mutex;
 static pthread_mutexattr_t mutex_attr;
-static pthread_cond_t cond;
+static pi_cond_t cond;
 static pthread_t threads[THREADS_NUM];
 static int pending = 0;
 
@@ -46,9 +46,9 @@ void *thread_fun_timed(void *arg)
 	printf("Started thread_fun_timed[%d]\n", *ret);
 
 	for (i = 0; i < MAXITER / THREADS_NUM; i++) {
-		rv = pthread_mutex_lock(&mutex);
+		rv = pi_mutex_lock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_lock: %s(%d)\n", strerror(rv),
 			       rv);
 			*ret = 1;
 			goto out;
@@ -58,11 +58,11 @@ void *thread_fun_timed(void *arg)
 			struct timespec ts;
 			clock_gettime(CLOCK_REALTIME, &ts);
 			ts.tv_sec += 20;
-			rv = pthread_cond_timedwait(&cond, &mutex, &ts);
+			rv = pi_cond_timedwait(&cond, &ts);
 
 			/* There should be no timeout either.  */
 			if (rv) {
-				printf("pthread_cond_wait: %s(%d)\n",
+				printf("pi_cond_wait: %s(%d)\n",
 				       strerror(rv), rv);
 				*ret = 1;
 				goto out;
@@ -71,9 +71,9 @@ void *thread_fun_timed(void *arg)
 
 		pending--;
 
-		rv = pthread_mutex_unlock(&mutex);
+		rv = pi_mutex_unlock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_unlock: %s(%d)\n", strerror(rv),
 			       rv);
 			*ret = 1;
 			goto out;
@@ -94,19 +94,19 @@ void *thread_fun(void *arg)
 	printf("Started thread_fun[%d]\n", *ret);
 
 	for (i = 0; i < MAXITER / THREADS_NUM; i++) {
-		rv = pthread_mutex_lock(&mutex);
+		rv = pi_mutex_lock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_lock: %s(%d)\n", strerror(rv),
 			       rv);
 			*ret = 1;
 			goto out;
 		}
 
 		while (!pending) {
-			rv = pthread_cond_wait(&cond, &mutex);
+			rv = pi_cond_wait(&cond);
 
 			if (rv) {
-				printf("pthread_cond_wait: %s(%d)\n",
+				printf("pi_cond_wait: %s(%d)\n",
 				       strerror(rv), rv);
 				*ret = 1;
 				goto out;
@@ -115,9 +115,9 @@ void *thread_fun(void *arg)
 
 		pending--;
 
-		rv = pthread_mutex_unlock(&mutex);
+		rv = pi_mutex_unlock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_unlock: %s(%d)\n", strerror(rv),
 			       rv);
 			*ret = 1;
 			goto out;
@@ -152,15 +152,15 @@ static int do_test_wait(threadfunc f)
 		return 1;
 	}
 
-	rv = pthread_mutex_init(&mutex, &mutex_attr);
+	rv = pi_mutex_init(&mutex, &mutex_attr);
 	if (rv) {
-		printf("pthread_mutex_init: %s(%d)\n", strerror(rv), rv);
+		printf("pi_mutex_init: %s(%d)\n", strerror(rv), rv);
 		return 1;
 	}
 
-	rv = pthread_cond_init(&cond, NULL);
+	rv = pi_cond_init(&cond, NULL);
 	if (rv) {
-		printf("pthread_cond_init: %s(%d)\n", strerror(rv), rv);
+		printf("pi_cond_init: %s(%d)\n", strerror(rv), rv);
 		return 1;
 	}
 
@@ -174,9 +174,9 @@ static int do_test_wait(threadfunc f)
 	}
 
 	for (; counter < MAXITER; counter++) {
-		rv = pthread_mutex_lock(&mutex);
+		rv = pi_mutex_lock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_lock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_lock: %s(%d)\n", strerror(rv),
 			       rv);
 			return 1;
 		}
@@ -185,16 +185,16 @@ static int do_test_wait(threadfunc f)
 			printf("counter: %d\n", counter);
 		pending += 1;
 
-		rv = pthread_cond_signal(&cond);
+		rv = pi_cond_signal(&cond);
 		if (rv) {
-			printf("pthread_cond_signal: %s(%d)\n", strerror(rv),
+			printf("pi_cond_signal: %s(%d)\n", strerror(rv),
 			       rv);
 			return 1;
 		}
 
-		rv = pthread_mutex_unlock(&mutex);
+		rv = pi_mutex_unlock(&mutex);
 		if (rv) {
-			printf("pthread_mutex_unlock: %s(%d)\n", strerror(rv),
+			printf("pi_mutex_unlock: %s(%d)\n", strerror(rv),
 			       rv);
 			return 1;
 		}
@@ -218,12 +218,12 @@ static int do_test_wait(threadfunc f)
 
 static int do_test(void)
 {
-	puts("Testing pthread_cond_wait");
+	puts("Testing pi_cond_wait");
 	int ret = do_test_wait(thread_fun);
 	if (ret)
 		return ret;
 
-	puts("Testing pthread_cond_timedwait");
+	puts("Testing pi_cond_timedwait");
 	return do_test_wait(thread_fun_timed);
 }
 

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -27,11 +27,12 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include "rtpi.h"
+
 #define THREADS_NUM 5
 #define MAXITER 50000
 
 static pi_mutex_t mutex;
-static pthread_mutexattr_t mutex_attr;
 static pi_cond_t cond;
 static pthread_t threads[THREADS_NUM];
 static int pending = 0;
@@ -139,26 +140,13 @@ static int do_test_wait(threadfunc f)
 
 	puts("Starting test");
 
-	rv = pthread_mutexattr_init(&mutex_attr);
-	if (rv) {
-		printf("pthread_mutexattr_init: %s(%d)\n", strerror(rv), rv);
-		return 1;
-	}
-
-	rv = pthread_mutexattr_setprotocol(&mutex_attr, PTHREAD_PRIO_INHERIT);
-	if (rv) {
-		printf("pthread_mutexattr_setprotocol: %s(%d)\n", strerror(rv),
-		       rv);
-		return 1;
-	}
-
-	rv = pi_mutex_init(&mutex, &mutex_attr);
+	rv = pi_mutex_init(&mutex, 0);
 	if (rv) {
 		printf("pi_mutex_init: %s(%d)\n", strerror(rv), rv);
 		return 1;
 	}
 
-	rv = pi_cond_init(&cond, NULL);
+	rv = pi_cond_init(&cond, &mutex, 0);
 	if (rv) {
 		printf("pi_cond_init: %s(%d)\n", strerror(rv), rv);
 		return 1;

--- a/tests/glibc-tests/tst-cond25.c
+++ b/tests/glibc-tests/tst-cond25.c
@@ -29,6 +29,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include "rtpi.h"
+
 #define NUM 5
 #define ITERS 10000
 #define COUNT 100
@@ -184,31 +186,17 @@ int do_test_wait(thr_func f)
 {
 	pthread_t w[NUM];
 	pthread_t s;
-	pthread_mutexattr_t attr;
 	int i, j, ret = 0;
 	void *thr_ret;
 
 	for (i = 0; i < COUNT; i++) {
-		if ((ret = pthread_mutexattr_init(&attr)) != 0) {
-			printf("mutexattr_init failed: %s\n", strerror(ret));
-			goto out;
-		}
-
-		if ((ret = pthread_mutexattr_setprotocol(&attr,
-							 PTHREAD_PRIO_INHERIT))
-		    != 0) {
-			printf("mutexattr_setprotocol failed: %s\n",
-			       strerror(ret));
-			goto out;
-		}
-
-		if ((ret = pi_cond_init(&cond, NULL)) != 0) {
-			printf("cond_init failed: %s\n", strerror(ret));
-			goto out;
-		}
-
-		if ((ret = pi_mutex_init(&mutex, &attr)) != 0) {
+		if ((ret = pi_mutex_init(&mutex, 0)) != 0) {
 			printf("mutex_init failed: %s\n", strerror(ret));
+			goto out;
+		}
+
+		if ((ret = pi_cond_init(&cond, &mutex, 0)) != 0) {
+			printf("cond_init failed: %s\n", strerror(ret));
 			goto out;
 		}
 

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -29,8 +29,8 @@ static int do_test(void);
    required that there are no spurious wakeups if only more readers
    are added.  This is a reasonable demand.  */
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
 
 #define N 10
 
@@ -40,15 +40,15 @@ static void *tf(void *arg)
 	int err;
 
 	/* Get the mutex.  */
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0) {
 		printf("child %d mutex_lock failed: %s\n", i, strerror(err));
 		exit(1);
 	}
 
 	/* This call should never return.  */
-	xpthread_cond_wait(&cond, &mut);
-	puts("error: pthread_cond_wait in tf returned");
+	xpi_cond_wait(&cond);
+	puts("error: pi_cond_wait in tf returned");
 
 	/* We should never get here.  */
 	exit(1);
@@ -66,7 +66,7 @@ static int do_test(void)
 
 		if (i != 0) {
 			/* Release the mutex.  */
-			err = pthread_mutex_unlock(&mut);
+			err = pi_mutex_unlock(&mut);
 			if (err != 0) {
 				printf("mutex_unlock %d failed: %s\n", i,
 				       strerror(err));
@@ -81,7 +81,7 @@ static int do_test(void)
 		}
 
 		/* Get the mutex.  */
-		err = pthread_mutex_lock(&mut);
+		err = pi_mutex_lock(&mut);
 		if (err != 0) {
 			printf("mutex_lock %d failed: %s\n", i, strerror(err));
 			return 1;
@@ -91,8 +91,8 @@ static int do_test(void)
 	delayed_exit(1);
 
 	/* This call should never return.  */
-	xpthread_cond_wait(&cond, &mut);
+	xpi_cond_wait(&cond);
 
-	puts("error: pthread_cond_wait in do_test returned");
+	puts("error: pi_cond_wait in do_test returned");
 	return 1;
 }

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "rtpi.h"
 
 static int do_test(void);
 #include "test-driver.c"
@@ -29,8 +30,8 @@ static int do_test(void);
    required that there are no spurious wakeups if only more readers
    are added.  This is a reasonable demand.  */
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 
 #define N 10
 

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -17,7 +17,6 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include <errno.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,6 +24,8 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/wait.h>
+
+#include "rtpi.h"
 
 int *condition;
 
@@ -35,14 +36,11 @@ static int do_test(void)
 	char data[ps];
 	void *mem;
 	int fd;
-	pthread_mutexattr_t ma;
 	pi_mutex_t *mut1;
 	pi_mutex_t *mut2;
-	pthread_condattr_t ca;
 	pi_cond_t *cond;
 	pid_t pid;
 	int result = 0;
-	int p;
 
 	fd = mkstemp(tmpfname);
 	if (fd == -1) {
@@ -80,77 +78,17 @@ static int do_test(void)
 	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
 			    & ~(__alignof(int) - 1));
 
-	if (pthread_mutexattr_init(&ma) != 0) {
-		puts("mutexattr_init failed");
-		return 1;
-	}
-
-	if (pthread_mutexattr_getpshared(&ma, &p) != 0) {
-		puts("1st mutexattr_getpshared failed");
-		return 1;
-	}
-
-	if (p != PTHREAD_PROCESS_PRIVATE) {
-		puts("default pshared value wrong");
-		return 1;
-	}
-
-	if (pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED) != 0) {
-		puts("mutexattr_setpshared failed");
-		return 1;
-	}
-
-	if (pthread_mutexattr_getpshared(&ma, &p) != 0) {
-		puts("2nd mutexattr_getpshared failed");
-		return 1;
-	}
-
-	if (p != PTHREAD_PROCESS_SHARED) {
-		puts("pshared value after setpshared call wrong");
-		return 1;
-	}
-
-	if (pi_mutex_init(mut1, &ma) != 0) {
+	if (pi_mutex_init(mut1, RTPI_MUTEX_PSHARED) != 0) {
 		puts("1st mutex_init failed");
 		return 1;
 	}
 
-	if (pi_mutex_init(mut2, &ma) != 0) {
+	if (pi_mutex_init(mut2, RTPI_MUTEX_PSHARED) != 0) {
 		puts("2nd mutex_init failed");
 		return 1;
 	}
 
-	if (pthread_condattr_init(&ca) != 0) {
-		puts("condattr_init failed");
-		return 1;
-	}
-
-	if (pthread_condattr_getpshared(&ca, &p) != 0) {
-		puts("1st condattr_getpshared failed");
-		return 1;
-	}
-
-	if (p != PTHREAD_PROCESS_PRIVATE) {
-		puts("default value for pshared in condattr wrong");
-		return 1;
-	}
-
-	if (pthread_condattr_setpshared(&ca, PTHREAD_PROCESS_SHARED) != 0) {
-		puts("condattr_setpshared failed");
-		return 1;
-	}
-
-	if (pthread_condattr_getpshared(&ca, &p) != 0) {
-		puts("2nd condattr_getpshared failed");
-		return 1;
-	}
-
-	if (p != PTHREAD_PROCESS_SHARED) {
-		puts("pshared condattr still not set");
-		return 1;
-	}
-
-	if (pi_cond_init(cond, &ca) != 0) {
+	if (pi_cond_init(cond, mut2, RTPI_COND_PSHARED) != 0) {
 		puts("cond_init failed");
 		return 1;
 	}

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -36,10 +36,10 @@ static int do_test(void)
 	void *mem;
 	int fd;
 	pthread_mutexattr_t ma;
-	pthread_mutex_t *mut1;
-	pthread_mutex_t *mut2;
+	pi_mutex_t *mut1;
+	pi_mutex_t *mut2;
 	pthread_condattr_t ca;
-	pthread_cond_t *cond;
+	pi_cond_t *cond;
 	pid_t pid;
 	int result = 0;
 	int p;
@@ -68,14 +68,14 @@ static int do_test(void)
 		return 1;
 	}
 
-	mut1 = (pthread_mutex_t *) (((uintptr_t) mem
-				     + __alignof(pthread_mutex_t))
-				    & ~(__alignof(pthread_mutex_t) - 1));
+	mut1 = (pi_mutex_t *) (((uintptr_t) mem
+				     + __alignof(pi_mutex_t))
+				    & ~(__alignof(pi_mutex_t) - 1));
 	mut2 = mut1 + 1;
 
-	cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
-				    + __alignof(pthread_cond_t))
-				   & ~(__alignof(pthread_cond_t) - 1));
+	cond = (pi_cond_t *) (((uintptr_t) (mut2 + 1)
+				    + __alignof(pi_cond_t))
+				   & ~(__alignof(pi_cond_t) - 1));
 
 	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
 			    & ~(__alignof(int) - 1));
@@ -110,12 +110,12 @@ static int do_test(void)
 		return 1;
 	}
 
-	if (pthread_mutex_init(mut1, &ma) != 0) {
+	if (pi_mutex_init(mut1, &ma) != 0) {
 		puts("1st mutex_init failed");
 		return 1;
 	}
 
-	if (pthread_mutex_init(mut2, &ma) != 0) {
+	if (pi_mutex_init(mut2, &ma) != 0) {
 		puts("2nd mutex_init failed");
 		return 1;
 	}
@@ -150,12 +150,12 @@ static int do_test(void)
 		return 1;
 	}
 
-	if (pthread_cond_init(cond, &ca) != 0) {
+	if (pi_cond_init(cond, &ca) != 0) {
 		puts("cond_init failed");
 		return 1;
 	}
 
-	if (pthread_mutex_lock(mut1) != 0) {
+	if (pi_mutex_lock(mut1) != 0) {
 		puts("parent: 1st mutex_lock failed");
 		return 1;
 	}
@@ -166,24 +166,24 @@ static int do_test(void)
 		puts("fork failed");
 		return 1;
 	} else if (pid == 0) {
-		if (pthread_mutex_lock(mut2) != 0) {
+		if (pi_mutex_lock(mut2) != 0) {
 			puts("child: mutex_lock failed");
 			return 1;
 		}
 
-		if (pthread_mutex_unlock(mut1) != 0) {
+		if (pi_mutex_unlock(mut1) != 0) {
 			puts("child: 1st mutex_unlock failed");
 			return 1;
 		}
 
 		do
-			if (pthread_cond_wait(cond, mut2) != 0) {
+			if (pi_cond_wait(cond) != 0) {
 				puts("child: cond_wait failed");
 				return 1;
 			}
 		while (*condition == 0) ;
 
-		if (pthread_mutex_unlock(mut2) != 0) {
+		if (pi_mutex_unlock(mut2) != 0) {
 			puts("child: 2nd mutex_unlock failed");
 			return 1;
 		}
@@ -192,24 +192,24 @@ static int do_test(void)
 	} else {
 		int status;
 
-		if (pthread_mutex_lock(mut1) != 0) {
+		if (pi_mutex_lock(mut1) != 0) {
 			puts("parent: 2nd mutex_lock failed");
 			return 1;
 		}
 
-		if (pthread_mutex_lock(mut2) != 0) {
+		if (pi_mutex_lock(mut2) != 0) {
 			puts("parent: 3rd mutex_lock failed");
 			return 1;
 		}
 
-		if (pthread_cond_signal(cond) != 0) {
+		if (pi_cond_signal(cond) != 0) {
 			puts("parent: cond_signal failed");
 			return 1;
 		}
 
 		*condition = 1;
 
-		if (pthread_mutex_unlock(mut2) != 0) {
+		if (pi_mutex_unlock(mut2) != 0) {
 			puts("parent: mutex_unlock failed");
 			return 1;
 		}

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -24,30 +24,16 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pi_mutex_t mut;
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+#include "rtpi.h"
+
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 
 static int do_test(void)
 {
-	pthread_mutexattr_t ma;
 	int err;
 	struct timespec ts;
 	struct timeval tv;
-
-	if (pthread_mutexattr_init(&ma) != 0) {
-		puts("mutexattr_init failed");
-		exit(1);
-	}
-
-	if (pthread_mutexattr_settype(&ma, PTHREAD_MUTEX_ERRORCHECK) != 0) {
-		puts("mutexattr_settype failed");
-		exit(1);
-	}
-
-	if (pi_mutex_init(&mut, &ma) != 0) {
-		puts("mutex_init failed");
-		exit(1);
-	}
 
 	/* Get the mutex.  */
 	if (pi_mutex_lock(&mut) != 0) {

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -24,8 +24,8 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pthread_mutex_t mut;
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
 
 static int do_test(void)
 {
@@ -44,13 +44,13 @@ static int do_test(void)
 		exit(1);
 	}
 
-	if (pthread_mutex_init(&mut, &ma) != 0) {
+	if (pi_mutex_init(&mut, &ma) != 0) {
 		puts("mutex_init failed");
 		exit(1);
 	}
 
 	/* Get the mutex.  */
-	if (pthread_mutex_lock(&mut) != 0) {
+	if (pi_mutex_lock(&mut) != 0) {
 		puts("mutex_lock failed");
 		exit(1);
 	}
@@ -67,7 +67,7 @@ static int do_test(void)
 		ts.tv_nsec -= 1000000000;
 		++ts.tv_sec;
 	}
-	err = pthread_cond_timedwait(&cond, &mut, &ts);
+	err = pi_cond_timedwait(&cond, &ts);
 	if (err == 0) {
 		/* This could in theory happen but here without any signal and
 		   additional waiter it should not.  */
@@ -78,7 +78,7 @@ static int do_test(void)
 		exit(1);
 	}
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0) {
 		printf("mutex_unlock failed: %s\n", strerror(err));
 		exit(1);

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -17,7 +17,6 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include <errno.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,6 +27,8 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 
+#include "rtpi.h"
+
 int *condition;
 
 static int do_test(void)
@@ -37,10 +38,8 @@ static int do_test(void)
 	char data[ps];
 	void *mem;
 	int fd;
-	pthread_mutexattr_t ma;
 	pi_mutex_t *mut1;
 	pi_mutex_t *mut2;
-	pthread_condattr_t ca;
 	pi_cond_t *cond;
 	pid_t pid;
 	int result = 0;
@@ -81,37 +80,17 @@ static int do_test(void)
 	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
 			    & ~(__alignof(int) - 1));
 
-	if (pthread_mutexattr_init(&ma) != 0) {
-		puts("mutexattr_init failed");
-		exit(1);
-	}
-
-	if (pthread_mutexattr_setpshared(&ma, PTHREAD_PROCESS_SHARED) != 0) {
-		puts("mutexattr_setpshared failed");
-		exit(1);
-	}
-
-	if (pi_mutex_init(mut1, &ma) != 0) {
+	if (pi_mutex_init(mut1, RTPI_MUTEX_PSHARED) != 0) {
 		puts("1st mutex_init failed");
 		exit(1);
 	}
 
-	if (pi_mutex_init(mut2, &ma) != 0) {
+	if (pi_mutex_init(mut2, RTPI_MUTEX_PSHARED) != 0) {
 		puts("2nd mutex_init failed");
 		exit(1);
 	}
 
-	if (pthread_condattr_init(&ca) != 0) {
-		puts("condattr_init failed");
-		exit(1);
-	}
-
-	if (pthread_condattr_setpshared(&ca, PTHREAD_PROCESS_SHARED) != 0) {
-		puts("condattr_setpshared failed");
-		exit(1);
-	}
-
-	if (pi_cond_init(cond, &ca) != 0) {
+	if (pi_cond_init(cond, mut2, RTPI_COND_PSHARED) != 0) {
 		puts("cond_init failed");
 		exit(1);
 	}

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -38,10 +38,10 @@ static int do_test(void)
 	void *mem;
 	int fd;
 	pthread_mutexattr_t ma;
-	pthread_mutex_t *mut1;
-	pthread_mutex_t *mut2;
+	pi_mutex_t *mut1;
+	pi_mutex_t *mut2;
 	pthread_condattr_t ca;
-	pthread_cond_t *cond;
+	pi_cond_t *cond;
 	pid_t pid;
 	int result = 0;
 
@@ -69,14 +69,14 @@ static int do_test(void)
 		exit(1);
 	}
 
-	mut1 = (pthread_mutex_t *) (((uintptr_t) mem
-				     + __alignof(pthread_mutex_t))
-				    & ~(__alignof(pthread_mutex_t) - 1));
+	mut1 = (pi_mutex_t *) (((uintptr_t) mem
+				     + __alignof(pi_mutex_t))
+				    & ~(__alignof(pi_mutex_t) - 1));
 	mut2 = mut1 + 1;
 
-	cond = (pthread_cond_t *) (((uintptr_t) (mut2 + 1)
-				    + __alignof(pthread_cond_t))
-				   & ~(__alignof(pthread_cond_t) - 1));
+	cond = (pi_cond_t *) (((uintptr_t) (mut2 + 1)
+				    + __alignof(pi_cond_t))
+				   & ~(__alignof(pi_cond_t) - 1));
 
 	condition = (int *)(((uintptr_t) (cond + 1) + __alignof(int))
 			    & ~(__alignof(int) - 1));
@@ -91,12 +91,12 @@ static int do_test(void)
 		exit(1);
 	}
 
-	if (pthread_mutex_init(mut1, &ma) != 0) {
+	if (pi_mutex_init(mut1, &ma) != 0) {
 		puts("1st mutex_init failed");
 		exit(1);
 	}
 
-	if (pthread_mutex_init(mut2, &ma) != 0) {
+	if (pi_mutex_init(mut2, &ma) != 0) {
 		puts("2nd mutex_init failed");
 		exit(1);
 	}
@@ -111,12 +111,12 @@ static int do_test(void)
 		exit(1);
 	}
 
-	if (pthread_cond_init(cond, &ca) != 0) {
+	if (pi_cond_init(cond, &ca) != 0) {
 		puts("cond_init failed");
 		exit(1);
 	}
 
-	if (pthread_mutex_lock(mut1) != 0) {
+	if (pi_mutex_lock(mut1) != 0) {
 		puts("parent: 1st mutex_lock failed");
 		exit(1);
 	}
@@ -130,12 +130,12 @@ static int do_test(void)
 		struct timespec ts;
 		struct timeval tv;
 
-		if (pthread_mutex_lock(mut2) != 0) {
+		if (pi_mutex_lock(mut2) != 0) {
 			puts("child: mutex_lock failed");
 			exit(1);
 		}
 
-		if (pthread_mutex_unlock(mut1) != 0) {
+		if (pi_mutex_unlock(mut1) != 0) {
 			puts("child: 1st mutex_unlock failed");
 			exit(1);
 		}
@@ -153,13 +153,13 @@ static int do_test(void)
 		}
 
 		do
-			if (pthread_cond_timedwait(cond, mut2, &ts) != 0) {
+			if (pi_cond_timedwait(cond, &ts) != 0) {
 				puts("child: cond_wait failed");
 				exit(1);
 			}
 		while (*condition == 0) ;
 
-		if (pthread_mutex_unlock(mut2) != 0) {
+		if (pi_mutex_unlock(mut2) != 0) {
 			puts("child: 2nd mutex_unlock failed");
 			exit(1);
 		}
@@ -168,24 +168,24 @@ static int do_test(void)
 	} else {
 		int status;
 
-		if (pthread_mutex_lock(mut1) != 0) {
+		if (pi_mutex_lock(mut1) != 0) {
 			puts("parent: 2nd mutex_lock failed");
 			exit(1);
 		}
 
-		if (pthread_mutex_lock(mut2) != 0) {
+		if (pi_mutex_lock(mut2) != 0) {
 			puts("parent: 3rd mutex_lock failed");
 			exit(1);
 		}
 
-		if (pthread_cond_signal(cond) != 0) {
+		if (pi_cond_signal(cond) != 0) {
 			puts("parent: cond_signal failed");
 			exit(1);
 		}
 
 		*condition = 1;
 
-		if (pthread_mutex_unlock(mut2) != 0) {
+		if (pi_mutex_unlock(mut2) != 0) {
 			puts("parent: mutex_unlock failed");
 			exit(1);
 		}

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -26,8 +26,8 @@
 #include <sys/time.h>
 
 typedef struct {
-	pthread_cond_t cond;
-	pthread_mutex_t lock;
+	pi_cond_t cond;
+	pi_mutex_t lock;
 	pthread_t h;
 } T;
 
@@ -45,24 +45,24 @@ static void *tf(void *arg)
 
 	T *t = (T *) arg;
 
-	if (pthread_mutex_lock(&t->lock) != 0) {
+	if (pi_mutex_lock(&t->lock) != 0) {
 		puts("child: lock failed");
 		exit(1);
 	}
 
 	done = true;
 
-	if (pthread_cond_signal(&t->cond) != 0) {
+	if (pi_cond_signal(&t->cond) != 0) {
 		puts("child: cond_signal failed");
 		exit(1);
 	}
 
-	if (pthread_cond_wait(&t->cond, &t->lock) != 0) {
+	if (pi_cond_wait(&t->cond) != 0) {
 		puts("child: cond_wait failed");
 		exit(1);
 	}
 
-	if (pthread_mutex_unlock(&t->lock) != 0) {
+	if (pi_mutex_unlock(&t->lock) != 0) {
 		puts("child: unlock failed");
 		exit(1);
 	}
@@ -84,13 +84,13 @@ static int do_test(void)
 			exit(1);
 		}
 
-		if (pthread_mutex_init(&t[i]->lock, NULL) != 0
-		    || pthread_cond_init(&t[i]->cond, NULL) != 0) {
+		if (pi_mutex_init(&t[i]->lock, NULL) != 0
+		    || pi_cond_init(&t[i]->cond, NULL) != 0) {
 			puts("an _init function failed");
 			exit(1);
 		}
 
-		if (pthread_mutex_lock(&t[i]->lock) != 0) {
+		if (pi_mutex_lock(&t[i]->lock) != 0) {
 			puts("initial mutex_lock failed");
 			exit(1);
 		}
@@ -103,14 +103,14 @@ static int do_test(void)
 		}
 
 		do
-			if (pthread_cond_wait(&t[i]->cond, &t[i]->lock) != 0) {
+			if (pi_cond_wait(&t[i]->cond) != 0) {
 				puts("cond_wait failed");
 				exit(1);
 			}
 		while (!done) ;
 
 		/* Release the lock since the cancel handler will get it.  */
-		if (pthread_mutex_unlock(&t[i]->lock) != 0) {
+		if (pi_mutex_unlock(&t[i]->lock) != 0) {
 			puts("mutex_unlock failed");
 			exit(1);
 		}

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -23,14 +23,14 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 
 static pthread_barrier_t bar;
 
 static void ch(void *arg)
 {
-	int e = pthread_mutex_lock(&mut);
+	int e = pi_mutex_lock(&mut);
 	if (e == 0) {
 		puts("mutex not locked at all by cond_wait");
 		exit(1);
@@ -41,7 +41,7 @@ static void ch(void *arg)
 		exit(1);
 	}
 
-	if (pthread_mutex_unlock(&mut) != 0) {
+	if (pi_mutex_unlock(&mut) != 0) {
 		puts("ch: cannot unlock mutex");
 		exit(1);
 	}
@@ -59,7 +59,7 @@ static void *tf1(void *p)
 		exit(1);
 	}
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0) {
 		puts("child: cannot get mutex");
 		exit(1);
@@ -75,7 +75,7 @@ static void *tf1(void *p)
 
 	pthread_cleanup_push(ch, NULL);
 
-	pthread_cond_wait(&cond, &mut);
+	pi_cond_wait(&cond);
 
 	pthread_cleanup_pop(0);
 
@@ -94,7 +94,7 @@ static void *tf2(void *p)
 		exit(1);
 	}
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0) {
 		puts("child: cannot get mutex");
 		exit(1);
@@ -118,7 +118,7 @@ static void *tf2(void *p)
 	TIMEVAL_TO_TIMESPEC(&tv, &ts);
 	ts.tv_sec += 1000;
 
-	pthread_cond_timedwait(&cond, &mut, &ts);
+	pi_cond_timedwait(&cond, &ts);
 
 	pthread_cleanup_pop(0);
 
@@ -158,13 +158,13 @@ static int do_test(void)
 		exit(1);
 	}
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0) {
 		puts("parent: mutex_lock failed");
 		exit(1);
 	}
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0) {
 		puts("parent: mutex_unlock failed");
 		exit(1);
@@ -203,13 +203,13 @@ static int do_test(void)
 		exit(1);
 	}
 
-	err = pthread_mutex_lock(&mut);
+	err = pi_mutex_lock(&mut);
 	if (err != 0) {
 		puts("parent: mutex_lock failed");
 		exit(1);
 	}
 
-	err = pthread_mutex_unlock(&mut);
+	err = pi_mutex_unlock(&mut);
 	if (err != 0) {
 		puts("parent: mutex_unlock failed");
 		exit(1);

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -23,9 +23,10 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+#include "rtpi.h"
 
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 static pthread_barrier_t bar;
 
 static void ch(void *arg)

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -23,8 +23,10 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pi_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+#include "rtpi.h"
+
+static DEFINE_PI_MUTEX(mut, 0);
+static DEFINE_PI_COND(cond, &mut, 0);
 
 static void *tf(void *arg)
 {

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -23,12 +23,12 @@
 #include <time.h>
 #include <sys/time.h>
 
-static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
+static pi_cond_t cond = PTHREAD_COND_INITIALIZER;
+static pi_mutex_t mut = PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 
 static void *tf(void *arg)
 {
-	int err = pthread_cond_wait(&cond, &mut);
+	int err = pi_cond_wait(&cond);
 	if (err == 0) {
 		puts("cond_wait did not fail");
 		exit(1);
@@ -47,7 +47,7 @@ static void *tf(void *arg)
 	TIMEVAL_TO_TIMESPEC(&tv, &ts);
 	ts.tv_sec += 1000;
 
-	err = pthread_cond_timedwait(&cond, &mut, &ts);
+	err = pi_cond_timedwait(&cond, &ts);
 	if (err == 0) {
 		puts("cond_timedwait did not fail");
 		exit(1);
@@ -68,7 +68,7 @@ static int do_test(void)
 
 	printf("&cond = %p\n&mut = %p\n", &cond, &mut);
 
-	err = pthread_cond_wait(&cond, &mut);
+	err = pi_cond_wait(&cond);
 	if (err == 0) {
 		puts("cond_wait did not fail");
 		exit(1);
@@ -87,7 +87,7 @@ static int do_test(void)
 	TIMEVAL_TO_TIMESPEC(&tv, &ts);
 	ts.tv_sec += 1000;
 
-	err = pthread_cond_timedwait(&cond, &mut, &ts);
+	err = pi_cond_timedwait(&cond, &ts);
 	if (err == 0) {
 		puts("cond_timedwait did not fail");
 		exit(1);
@@ -98,7 +98,7 @@ static int do_test(void)
 		exit(1);
 	}
 
-	if (pthread_mutex_lock(&mut) != 0) {
+	if (pi_mutex_lock(&mut) != 0) {
 		puts("parent: mutex_lock failed");
 		exit(1);
 	}

--- a/tools/convert
+++ b/tools/convert
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+    echo "Usage:"
+    echo -e "\t$0 <file_to_convert>"
+    exit 1
+fi
+
+mv "$1" "$1.old"
+
+sed 's/pthread_mutex_/pi_mutex_/g' "$1.old" | \
+sed 's/pthread_cond_/pi_cond_/g' | \
+sed 's/\(pi_cond_wait[\s]*([^,]*\)\([^\)]*\)/\1/g' | \
+sed 's/\(pi_cond_timedwait[\s]*([^,]*\)\(,[^,]*\)\([^\)]*\)/\1\3/g' > "$1"


### PR DESCRIPTION
This is a first pass bulk conversion of the imported glibc tests to the librtpi API.

The first two commits add a basic sed based script and use it to convert pthread_mutex_* references to pi_mutex_* and pthread_cond_* to pi_cond_*. The script also removes the mutex parameter (i.e. 2nd parameter) from pthread_wait() and pthread_timedwait() calls as this is not present in the librtpi API.

Static definitions and calls to pthread_mutex_init() and pthread_cond_init() are renamed to their librtpi equivalents but the conversion is only partial since it involves converting the pthread attribute uses.

The remaining commits in this series address this by:

- adding macros modelled after Linux kernel DEFINE_MUTEX() for statically defining and initializing a pi_mutex_t or pi_cond_t variable.
- converting statically initialized mutexes and condvars using the macros defined by the previous commit.
- converting mutex and condvar attributes to their equivalent librtpi flags passed to pi_mutex_init() and pi_cond_init() calls.

Providing a way to statically define and initialize a pi_mutex_t or pi_cond_t variable does have the downside of making these types less opaque and their sizes become part of librtpi ABI. To mitigate these downsides we:

- use a union in combination with an anonymous struct to provide some padding for future additions.
- provide a public "rtpi.h" include file and an internal one "rtpi_internal.h". This way a user should be able to tell what are public vs. internal APIs.

Having a way to statically define and initialize these variables does come with significant upsides:

- avoids dynamic memory allocations in RT threads.
- simplifies porting existing code. Most/All of the glibc tests ported over make use of static definitions. This is also true for existing code that uses condvars.

Changes from v1 (PR #16)

Commit 7f9dbd6ab39a ("pi_cond, pi_mutex: Add support for static definition and initialization") was modified to:

- Set padding and alignment for pi_mutex to 64 bytes. This matches the cache line size on most 64-bit machines and provides performance advantages in additon to room for future growth.

- Set padding for pi_cond to 128 bytes i.e. 2 cache lines on common 64-bit machines and alignment to 64 bytes for the same reasons as above.