### PR TITLE
Non POSIX changes to glibc tests

### DIFF
--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -107,22 +107,22 @@ static int do_test(void)
 			}
 		}
 
-		if (pi_mutex_lock(&mut) != 0) {
-			puts("parent: mutex_lock failed");
-			exit(1);
-		}
-		if (pi_mutex_unlock(&mut) != 0) {
-			puts("parent: mutex_unlock failed");
-			exit(1);
-		}
-
-		/* N single signal calls.  Without locking.  This tests that no
-		   signal gets lost.  */
-		for (i = 0; i < N; ++i)
+		/* N single signal calls. This tests that no signal
+		   gets lost. */
+		for (i = 0; i < N; ++i) {
+			if (pi_mutex_lock(&mut) != 0) {
+				puts("parent: mutex_lock failed");
+				exit(1);
+			}
 			if (pi_cond_signal(&cond) != 0) {
 				puts("cond_signal failed");
 				exit(1);
 			}
+			if (pi_mutex_unlock(&mut) != 0) {
+				puts("parent: mutex_unlock failed");
+				exit(1);
+			}
+		}
 
 		int e = pthread_barrier_wait(&bN1);
 		if (e != 0 && e != PTHREAD_BARRIER_SERIAL_THREAD) {

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -49,13 +49,9 @@ void *tf(void *dummy)
 		n = false;
 		if (exiting)
 			loop = false;
-#ifdef UNLOCK_AFTER_BROADCAST
+
 		pi_cond_broadcast(&cv);
 		pi_mutex_unlock(&lock);
-#else
-		pi_mutex_unlock(&lock);
-		pi_cond_broadcast(&cv);
-#endif
 	}
 
 	return NULL;

--- a/tests/glibc-tests/tst-cond17.c
+++ b/tests/glibc-tests/tst-cond17.c
@@ -1,2 +1,0 @@
-#define UNLOCK_AFTER_BROADCAST 1
-#include "tst-cond16.c"

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -32,7 +32,7 @@ static int do_test(void)
 	int result = 0;
 	struct timespec ts;
 
-	if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
 		puts("clock_gettime failed");
 		return 1;
 	}

--- a/tests/glibc-tests/tst-cond20.c
+++ b/tests/glibc-tests/tst-cond20.c
@@ -99,9 +99,6 @@ static int do_test(void)
 			pi_cond_wait(&cond2);
 		while (count != N);
 
-		if (i & 1)
-			pi_mutex_unlock(&mut);
-
 		if (i & 2)
 			pi_cond_broadcast(&cond);
 		else if (i & 4)
@@ -113,8 +110,7 @@ static int do_test(void)
 			pi_cond_broadcast(&cond);
 		}
 
-		if ((i & 1) == 0)
-			pi_mutex_unlock(&mut);
+		pi_mutex_unlock(&mut);
 
 		err = pi_cond_destroy(&cond);
 		if (err) {

--- a/tests/glibc-tests/tst-cond21.c
+++ b/tests/glibc-tests/tst-cond21.c
@@ -1,3 +1,3 @@
-#include <sys/time.h>
+#include <time.h>
 #define TIMED 1
 #include "tst-cond20.c"

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include "rtpi.h"
@@ -57,7 +56,7 @@ void *thread_fun_timed(void *arg)
 
 		while (!pending) {
 			struct timespec ts;
-			clock_gettime(CLOCK_REALTIME, &ts);
+			clock_gettime(CLOCK_MONOTONIC, &ts);
 			ts.tv_sec += 20;
 			rv = pi_cond_timedwait(&cond, &ts);
 

--- a/tests/glibc-tests/tst-cond25.c
+++ b/tests/glibc-tests/tst-cond25.c
@@ -26,7 +26,6 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include "rtpi.h"
@@ -139,7 +138,7 @@ void *timed_waiter(void *u)
 	for (i = 0; i < ITERS / NUM; i++) {
 		struct timespec ts;
 
-		if ((ret = clock_gettime(CLOCK_REALTIME, &ts)) != 0) {
+		if ((ret = clock_gettime(CLOCK_MONOTONIC, &ts)) != 0) {
 			tret = (void *)(uintptr_t) 1;
 			printf("%u:clock_gettime failed: %s\n", seq,
 			       strerror(errno));

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <sys/time.h>
 
 #include "rtpi.h"
 
@@ -33,7 +32,6 @@ static int do_test(void)
 {
 	int err;
 	struct timespec ts;
-	struct timeval tv;
 
 	/* Get the mutex.  */
 	if (pi_mutex_lock(&mut) != 0) {
@@ -42,12 +40,12 @@ static int do_test(void)
 	}
 
 	/* Waiting for the condition will fail.  But we want the timeout here.  */
-	if (gettimeofday(&tv, NULL) != 0) {
-		puts("gettimeofday failed");
+	err = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (err != 0) {
+		printf("clock_gettime failed with error %s\n", strerror(err));
 		exit(1);
 	}
 
-	TIMEVAL_TO_TIMESPEC(&tv, &ts);
 	ts.tv_nsec += 500000000;
 	if (ts.tv_nsec >= 1000000000) {
 		ts.tv_nsec -= 1000000000;

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -24,7 +24,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/mman.h>
-#include <sys/time.h>
 #include <sys/wait.h>
 
 #include "rtpi.h"
@@ -107,7 +106,6 @@ static int do_test(void)
 		exit(1);
 	} else if (pid == 0) {
 		struct timespec ts;
-		struct timeval tv;
 
 		if (pi_mutex_lock(mut2) != 0) {
 			puts("child: mutex_lock failed");
@@ -119,12 +117,11 @@ static int do_test(void)
 			exit(1);
 		}
 
-		if (gettimeofday(&tv, NULL) != 0) {
-			puts("gettimeofday failed");
+		if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+			puts("child: clock_gettime failed");
 			exit(1);
 		}
 
-		TIMEVAL_TO_TIMESPEC(&tv, &ts);
 		ts.tv_nsec += 500000000;
 		if (ts.tv_nsec >= 1000000000) {
 			ts.tv_nsec -= 1000000000;

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <sys/time.h>
 
 #include "rtpi.h"
 
@@ -87,6 +86,7 @@ static void *tf1(void *p)
 
 static void *tf2(void *p)
 {
+	struct timespec ts;
 	int err;
 
 	if (pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0
@@ -111,12 +111,11 @@ static void *tf2(void *p)
 
 	pthread_cleanup_push(ch, NULL);
 
-	/* Current time.  */
-	struct timeval tv;
-	(void)gettimeofday(&tv, NULL);
-	/* +1000 seconds in correct format.  */
-	struct timespec ts;
-	TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	err = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (err != 0) {
+		puts("child: clock_gettime failed");
+		exit(1);
+	}
 	ts.tv_sec += 1000;
 
 	pi_cond_timedwait(&cond, &ts);

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <sys/time.h>
 
 #include "rtpi.h"
 
@@ -41,12 +40,12 @@ static void *tf(void *arg)
 		exit(1);
 	}
 
-	/* Current time.  */
-	struct timeval tv;
-	(void)gettimeofday(&tv, NULL);
-	/* +1000 seconds in correct format.  */
 	struct timespec ts;
-	TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	err = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (err != 0) {
+		puts("child: clock_gettime failed");
+		exit(1);
+	}
 	ts.tv_sec += 1000;
 
 	err = pi_cond_timedwait(&cond, &ts);
@@ -65,6 +64,7 @@ static void *tf(void *arg)
 
 static int do_test(void)
 {
+	struct timespec ts;
 	pthread_t th;
 	int err;
 
@@ -82,11 +82,11 @@ static int do_test(void)
 	}
 
 	/* Current time.  */
-	struct timeval tv;
-	(void)gettimeofday(&tv, NULL);
-	/* +1000 seconds in correct format.  */
-	struct timespec ts;
-	TIMEVAL_TO_TIMESPEC(&tv, &ts);
+	err = clock_gettime(CLOCK_MONOTONIC, &ts);
+	if (err != 0) {
+		puts("clock_gettime failed");
+		exit(1);
+	}
 	ts.tv_sec += 1000;
 
 	err = pi_cond_timedwait(&cond, &ts);


### PR DESCRIPTION
By design librtpi deviates from POSIX in several places in order to guarantee better real-time behaviour. Specifically:

- The associated mutex must be held when the condition variable is signaled or broadcast.
- The default clock used for wait timeouts (pi_cond_timedwait) is CLOCK_MONOTONIC.

Adapt the imported glibc tests to these requirements.