### PR TITLE
One off test changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_CONFIG_FILES([
  Makefile
  src/Makefile
  tests/Makefile
+ tests/glibc-tests/Makefile
 ])
 AC_CONFIG_MACRO_DIRS([m4])
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,6 +3,7 @@
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src
 LDADD = $(top_builddir)/src/librtpi.la -lpthread
+SUBDIRS = glibc-tests
 
 check_PROGRAMS = test_api tst-cond1 tst-condpi2
 TESTS = test_api tst-cond1 tst-condpi2.sh

--- a/tests/glibc-tests/Makefile.am
+++ b/tests/glibc-tests/Makefile.am
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+# Copyright © 2019 National Instruments. All Rights Reserved.
+
+AM_CPPFLAGS = -I. -I$(top_srcdir)/src
+LDADD = $(top_builddir)/src/librtpi.la -lpthread
+
+check_PROGRAMS = tst-cond1 tst-cond2 tst-cond3
+
+TESTS = tst-cond1 tst-cond2 tst-cond3
+
+test: check

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -16,6 +16,7 @@
    License along with the GNU C Library; if not, see
    <http://www.gnu.org/licenses/>.  */
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -29,26 +29,23 @@
 static char fname[] = "/tmp/tst-cond12-XXXXXX";
 static int fd;
 
-static void prepare(void);
-#define PREPARE(argc, argv) prepare ()
-
-static int do_test(void);
-#define TEST_FUNCTION do_test ()
-
-#include "../test-skeleton.c"
-
-static void prepare(void)
+static void prepare(int argc, char* argv[])
 {
 	fd = mkstemp(fname);
 	if (fd == -1) {
 		printf("mkstemp failed: %m\n");
 		exit(1);
 	}
-	add_temp_file(fname);
+
 	if (ftruncate(fd, 1000) < 0) {
 		printf("ftruncate failed: %m\n");
 		exit(1);
 	}
+}
+
+static void cleanup(void)
+{
+	remove(fname);
 }
 
 static int do_test(void)

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -88,13 +88,6 @@ static int do_test(void)
 		status = 1;
 	}
 
-	printf("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
-	       c.__data.__wseq, c.__data.__g1_start,
-	       c.__data.__g_signals[0], c.__data.__g_refs[0],
-	       c.__data.__g_size[0], c.__data.__g_signals[1],
-	       c.__data.__g_refs[1], c.__data.__g_size[1],
-	       c.__data.__g1_orig_size, c.__data.__wrefs);
-
 	if (pthread_create(&th, NULL, tf, (void *)1l) != 0) {
 		puts("2nd create failed");
 		return 1;
@@ -124,13 +117,6 @@ static int do_test(void)
 		puts("2nd thread canceled");
 		status = 1;
 	}
-
-	printf("cond = { %llu, %llu, %u/%u/%u, %u/%u/%u, %u, %u }\n",
-	       c.__data.__wseq, c.__data.__g1_start,
-	       c.__data.__g_signals[0], c.__data.__g_refs[0],
-	       c.__data.__g_size[0], c.__data.__g_signals[1],
-	       c.__data.__g_refs[1], c.__data.__g_size[1],
-	       c.__data.__g1_orig_size, c.__data.__wrefs);
 
 	return status;
 }

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -48,7 +48,12 @@ static void *tf(void *arg)
 	}
 
 	/* This call should never return.  */
-	xpi_cond_wait(&cond);
+	err = pi_cond_wait(&cond);
+	if (err != 0) {
+		printf("child %d pi_cond_wait failed to wait: %s\n",
+		       i, strerror(err));
+		exit(1);
+	}
 	puts("error: pi_cond_wait in tf returned");
 
 	/* We should never get here.  */
@@ -92,7 +97,11 @@ static int do_test(void)
 	delayed_exit(1);
 
 	/* This call should never return.  */
-	xpi_cond_wait(&cond);
+	err = pi_cond_wait(&cond);
+	if (err != 0) {
+		puts("error: pi_cond_wait in do_test failed to wait");
+		return 1;
+	}
 
 	puts("error: pi_cond_wait in do_test returned");
 	return 1;

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -25,6 +25,8 @@
 #include <time.h>
 #include <sys/time.h>
 
+#include "rtpi.h"
+
 typedef struct {
 	pi_cond_t cond;
 	pi_mutex_t lock;
@@ -84,8 +86,8 @@ static int do_test(void)
 			exit(1);
 		}
 
-		if (pi_mutex_init(&t[i]->lock, NULL) != 0
-		    || pi_cond_init(&t[i]->cond, NULL) != 0) {
+		if (pi_mutex_init(&t[i]->lock, 0) != 0
+		    || pi_cond_init(&t[i]->cond, &t[i]->lock, 0) != 0) {
 			puts("an _init function failed");
 			exit(1);
 		}


### PR DESCRIPTION
This series of commits cover one-off test changes that where missed by the previous bulk glibc test conversion or are tweaks specific to a particular test.

After these changes we can start including the glibc tests in our test runs and the last commit in this series ("glibc-tests: Add glibc-tests to autoconf/automake") does so for tests that currently pass. Additional tests will be enabled as the underlying issues get addressed by future changes.