### PR TITLE
Fix error return paths/codes

### DIFF
--- a/src/pi_cond.c
+++ b/src/pi_cond.c
@@ -127,7 +127,7 @@ int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime)
 	if (ret)
 		return ret;
 	ret = futex_wait_requeue_pi(cond, 0, abstime, cond->mutex);
-	return ret;
+	return (ret) ? errno : 0;
 }
 
 int pi_cond_signal(pi_cond_t *cond)
@@ -204,7 +204,7 @@ int pi_cond_broadcast(pi_cond_t *cond)
 			cond->pending_wake = cond->pending_wait;
 			pi_mutex_unlock(&cond->priv_mut);
 		} else {
-			return ret;
+			return errno;
 		}
 	} while (1);
 	return 0;

--- a/src/pi_cond.c
+++ b/src/pi_cond.c
@@ -30,7 +30,7 @@ int pi_cond_init(pi_cond_t *cond, pi_mutex_t *mutex, uint32_t flags)
 	int ret;
 
 	if (flags & ~(RTPI_COND_PSHARED)) {
-		ret = -EINVAL;
+		ret = EINVAL;
 		goto out;
 	}
 	memset(cond, 0, sizeof(*cond));
@@ -40,7 +40,7 @@ int pi_cond_init(pi_cond_t *cond, pi_mutex_t *mutex, uint32_t flags)
 
 	/* PSHARED has to match on both. */
 	if ((cond->flags & RTPI_COND_PSHARED) ^ (mutex->flags % RTPI_MUTEX_PSHARED)) {
-		ret = -EINVAL;
+		ret = EINVAL;
 		goto out;
 	}
 	pi_mutex_init(&cond->priv_mut, cond->flags & RTPI_COND_PSHARED);
@@ -101,7 +101,7 @@ int pi_cond_wait(pi_cond_t *cond)
 				pi_mutex_lock(&cond->priv_mut);
 				cond->pending_wait--;
 				pi_mutex_unlock(&cond->priv_mut);
-				ret = -errno;
+				ret = errno;
 				break;
 			}
 		}
@@ -166,7 +166,7 @@ int pi_cond_signal(pi_cond_t *cond)
 			cond->wake_id = id;
 			pi_mutex_unlock(&cond->priv_mut);
 		} else {
-			return -errno;
+			return errno;
 		}
 	} while (1);
 	return 0;

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -58,7 +58,7 @@ int pi_mutex_lock(pi_mutex_t *mutex)
 	if (pi_mutex_trylock(mutex))
 		return 0;
 	/* XXX EWNERDEAD */
-	return futex_lock_pi(mutex);
+	return (futex_lock_pi(mutex)) ? errno : 0;
 }
 
 #define FUTEX_TID_MASK          0x3fffffff
@@ -93,5 +93,5 @@ int pi_mutex_unlock(pi_mutex_t *mutex)
 					   pid, 0);
 	if (ret == true)
 		return 0;
-	return futex_unlock_pi(mutex);
+	return (futex_unlock_pi(mutex)) ? errno : 0;
 }

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -55,9 +55,11 @@ int pi_mutex_destroy(pi_mutex_t *mutex)
 
 int pi_mutex_lock(pi_mutex_t *mutex)
 {
-	if (!pi_mutex_trylock(mutex))
-		return 0;
-	/* XXX EWNERDEAD */
+	int ret;
+
+	ret = pi_mutex_trylock(mutex);
+	if (!ret || ret == EDEADLOCK)
+		return ret;
 	return (futex_lock_pi(mutex)) ? errno : 0;
 }
 

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -55,7 +55,7 @@ int pi_mutex_destroy(pi_mutex_t *mutex)
 
 int pi_mutex_lock(pi_mutex_t *mutex)
 {
-	if (pi_mutex_trylock(mutex))
+	if (!pi_mutex_trylock(mutex))
 		return 0;
 	/* XXX EWNERDEAD */
 	return (futex_lock_pi(mutex)) ? errno : 0;
@@ -74,8 +74,8 @@ int pi_mutex_trylock(pi_mutex_t *mutex)
 
 	ret = __sync_bool_compare_and_swap(&mutex->futex,
 					   0, pid);
-	if (ret == true)
-		return 1;
+	if (!ret)
+		return EBUSY;
 	return 0;
 }
 

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -85,10 +85,9 @@ int pi_mutex_unlock(pi_mutex_t *mutex)
 	bool ret;
 
 	pid = gettid();
-#if 0
-	XXX
 	if (pid != (mutex->futex & FUTEX_TID_MASK))
-#endif
+		return EPERM;
+
 	ret = __sync_bool_compare_and_swap(&mutex->futex,
 					   pid, 0);
 	if (ret == true)

--- a/src/pi_mutex.c
+++ b/src/pi_mutex.c
@@ -36,7 +36,7 @@ int pi_mutex_init(pi_mutex_t *mutex, uint32_t flags)
 
 	/* Check for unknown options */
 	if (flags & ~(RTPI_MUTEX_PSHARED)) {
-		ret = -EINVAL;
+		ret = EINVAL;
 		goto out;
 	}
 
@@ -70,7 +70,7 @@ int pi_mutex_trylock(pi_mutex_t *mutex)
 
 	pid = gettid();
 	if (pid == (mutex->futex & FUTEX_TID_MASK))
-		return -EDEADLOCK;
+		return EDEADLOCK;
 
 	ret = __sync_bool_compare_and_swap(&mutex->futex,
 					   0, pid);

--- a/tests/glibc-tests/Makefile.am
+++ b/tests/glibc-tests/Makefile.am
@@ -4,8 +4,8 @@
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src
 LDADD = $(top_builddir)/src/librtpi.la -lpthread
 
-check_PROGRAMS = tst-cond1 tst-cond2 tst-cond3
+check_PROGRAMS = tst-cond1 tst-cond2 tst-cond3 tst-cond9
 
-TESTS = tst-cond1 tst-cond2 tst-cond3
+TESTS = tst-cond1 tst-cond2 tst-cond3 tst-cond9
 
 test: check


### PR DESCRIPTION
Several fixes to the pi_mutex and pi_cond error paths to match POSIX and glibc behaviour:

- return positive error numbers on failure and 0 on success;
- return EPERM if trying to unlock a mutex that was not locked by the current thread;
- return EBUSY in pi_mutex_trylock() if mutex already locked;
- early return EDEADLOCK in pi_mutex_lock() if current thread already owns the lock.

Fixes: tests/glibc-tests/tst-cond9.c