### PR TITLE
Update API to support process shared condvar use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ mutexattr with the PTHREAD_PRIO_INHERIT protocal set.
 New primitive modeled after the POSIX pthread_cond_t, with the following
 modifications.
 
-1. It must be associated with a pi_mutex_t at initialization time,
-preventing the practice of signaling the condition prior to the
-association of the mutex.
-2. All wakeup events will wake the N highest priority waiters.
-3. Waiters will be woken in priority FIFO order.
-4. The associated mutex must be held when the condition variable is signaled or
+1. All wakeup events will wake the N highest priority waiters.
+2. Waiters will be woken in priority FIFO order.
+3. The associated mutex must be held when the condition variable is signaled or
 broadcast.
+4. The associated mutex must be passed as a parameter to the signal and
+broadcast calls. The mutex is used to requeue woken waiters and avoid the
+"thundering herd" effect.
 
 ## Functions
 ### PI Mutex
@@ -113,20 +113,20 @@ Simple wrapper to pthread_mutex_unlock.
 The PI Condition API represents a new implementation of a Non-POSIX PI aware
 condition variable.
 
-#### int pi_cond_init(pi_cond_t \*cond, pi_mutex_t \*mutex, uint32_t flags)
+#### int pi_cond_init(pi_cond_t \*cond, uint32_t flags)
 
 ##### Where flags are:
 * RTPI_COND_PSHARED
 
 #### int pi_cond_destroy(pi_cond_t \*cond)
 
-#### int pi_cond_wait(pi_cond_t \*cond)
+#### int pi_cond_wait(pi_cond_t \*cond, pi_mutex_t \*mutex)
 
-#### int pi_cond_timedwait(pi_cond_t \*cond, const struct timespec \*restrict abstime)
+#### int pi_cond_timedwait(pi_cond_t \*cond, pi_mutex_t \*mutex, const struct timespec \*restrict abstime)
 
-#### int pi_cond_signal(pi_cond_t \*cond)
+#### int pi_cond_signal(pi_cond_t \*cond, pi_mutex_t \*mutex)
 
-#### int pi_cond_broadcast(pi_cond_t \*cond)
+#### int pi_cond_broadcast(pi_cond_t \*cond, pi_mutex_t \*mutex)
 
 ## Initializers
 
@@ -134,10 +134,9 @@ condition variable.
 
 Defines and initializes a PI aware mutex.
 
-#### DEFINE_PI_COND(condvar, mutex, flags)
+#### DEFINE_PI_COND(condvar, flags)
 
-Defines and initializes a PI aware conditional variable. The mutex is
-associated with the conditional variable at this time.
+Defines and initializes a PI aware conditional variable.
 
 # C++ Specification
 WRITEME - after the C Specification is complete

--- a/src/rtpi.h
+++ b/src/rtpi.h
@@ -43,8 +43,8 @@ int pi_mutex_unlock(pi_mutex_t *mutex);
 /*
  * PI Cond Interface
  */
-#define DEFINE_PI_COND(condvar, mutex, flags) \
-	pi_cond_t condvar = PI_COND_INIT(mutex, flags)
+#define DEFINE_PI_COND(condvar, flags) \
+	pi_cond_t condvar = PI_COND_INIT(flags)
 
 #define RTPI_COND_PSHARED     RTPI_MUTEX_PSHARED
 
@@ -52,16 +52,17 @@ pi_cond_t *pi_cond_alloc(void);
 
 void pi_cond_free(pi_cond_t *cond);
 
-int pi_cond_init(pi_cond_t *cond, pi_mutex_t *mutex, uint32_t flags);
+int pi_cond_init(pi_cond_t *cond, uint32_t flags);
 
 int pi_cond_destroy(pi_cond_t *cond);
 
-int pi_cond_wait(pi_cond_t *cond);
+int pi_cond_wait(pi_cond_t *cond, pi_mutex_t *mutex);
 
-int pi_cond_timedwait(pi_cond_t *cond, const struct timespec *restrict abstime);
+int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
+		      const struct timespec *restrict abstime);
 
-int pi_cond_signal(pi_cond_t *cond);
+int pi_cond_signal(pi_cond_t *cond, pi_mutex_t *mutex);
 
-int pi_cond_broadcast(pi_cond_t *cond);
+int pi_cond_broadcast(pi_cond_t *cond, pi_mutex_t *mutex);
 
 #endif // RTPI_H

--- a/src/rtpi_internal.h
+++ b/src/rtpi_internal.h
@@ -25,7 +25,6 @@ union pi_mutex {
 union pi_cond {
 	struct {
 		union pi_mutex	priv_mut;
-		union pi_mutex	*mutex;
 		__u32		cond;
 		__u32		flags;
 		__u32		wake_id;
@@ -35,9 +34,8 @@ union pi_cond {
 	__u8 pad[128];
 } __attribute__ ((aligned(64)));
 
-#define PI_COND_INIT(m, f) \
+#define PI_COND_INIT(f) \
 	{ .priv_mut = PI_MUTEX_INIT(f) \
-	, .mutex = m \
 	, .cond = 0 \
 	, .flags = f \
 	, .wake_id = 0 \

--- a/tests/glibc-tests/tst-cond-except.c
+++ b/tests/glibc-tests/tst-cond-except.c
@@ -50,7 +50,7 @@ void *thr(void *arg)
 	ret = pi_mutex_init(&mutex, 0);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_mutex_init");
 
-	ret = pi_cond_init(&cond, &mutex, 0);
+	ret = pi_cond_init(&cond, 0);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_cond_init");
 
 	puts("th: Init done, entering wait...");
@@ -59,7 +59,7 @@ void *thr(void *arg)
 	ret = pi_mutex_lock(&mutex);
 	CHECK_RETURN_VAL_OR_FAIL(ret, "pi_mutex_lock");
 	while (1) {
-		ret = pi_cond_wait(&cond);
+		ret = pi_cond_wait(&cond, &mutex);
 		CHECK_RETURN_VAL_OR_FAIL(ret, "pi_cond_wait");
 	}
 	pthread_cleanup_pop(1);

--- a/tests/glibc-tests/tst-cond1.c
+++ b/tests/glibc-tests/tst-cond1.c
@@ -23,7 +23,7 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 
 static void *tf(void *p)
 {
@@ -35,7 +35,7 @@ static void *tf(void *p)
 
 	puts("child: got mutex; signalling");
 
-	pi_cond_signal(&cond);
+	pi_cond_signal(&cond, &mut);
 
 	puts("child: unlock");
 
@@ -72,7 +72,7 @@ static int do_test(void)
 	/* This test will fail on spurious wake-ups, which are allowed; however,
 	   the current implementation shouldn't produce spurious wake-ups in the
 	   scenario we are testing here.  */
-	err = pi_cond_wait(&cond);
+	err = pi_cond_wait(&cond, &mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "parent: cannot wait fir signal");
 

--- a/tests/glibc-tests/tst-cond10.c
+++ b/tests/glibc-tests/tst-cond10.c
@@ -28,7 +28,7 @@
 #define ROUNDS 100
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 static pthread_barrier_t bN1;
 static pthread_barrier_t b2;
 
@@ -45,7 +45,7 @@ static void *tf(void *p)
 		exit(1);
 	}
 
-	if (pi_cond_wait(&cond) != 0) {
+	if (pi_cond_wait(&cond, &mut) != 0) {
 		puts("child: cond_wait failed");
 		exit(1);
 	}
@@ -114,7 +114,7 @@ static int do_test(void)
 				puts("parent: mutex_lock failed");
 				exit(1);
 			}
-			if (pi_cond_signal(&cond) != 0) {
+			if (pi_cond_signal(&cond, &mut) != 0) {
 				puts("cond_signal failed");
 				exit(1);
 			}

--- a/tests/glibc-tests/tst-cond11.c
+++ b/tests/glibc-tests/tst-cond11.c
@@ -47,7 +47,7 @@ static int run_test(clockid_t cl)
 		return 1;
 	}
 
-	if (pi_cond_init(&cond, &mut, flags) != 0) {
+	if (pi_cond_init(&cond, flags) != 0) {
 		puts("cond_init failed");
 		return 1;
 	}
@@ -71,7 +71,7 @@ static int run_test(clockid_t cl)
 	/* Wait one second.  */
 	++ts.tv_sec;
 
-	int e = pi_cond_timedwait(&cond, &ts);
+	int e = pi_cond_timedwait(&cond, &mut, &ts);
 	if (e == 0) {
 		puts("cond_timedwait succeeded");
 		return 1;

--- a/tests/glibc-tests/tst-cond12.c
+++ b/tests/glibc-tests/tst-cond12.c
@@ -67,7 +67,7 @@ static int do_test(void)
 		return 1;
 	}
 
-	if (pi_cond_init(&p->c, &p->m, RTPI_COND_PSHARED) != 0) {
+	if (pi_cond_init(&p->c, RTPI_COND_PSHARED) != 0) {
 		puts("mutex_init failed");
 		return 1;
 	}
@@ -107,13 +107,13 @@ static int do_test(void)
 		p->var = 0;
 
 #ifndef USE_COND_SIGNAL
-		if (pi_cond_broadcast(&p->c) != 0) {
+		if (pi_cond_broadcast(&p->c, &p->m) != 0) {
 			puts("child: cond_broadcast failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
 		}
 #else
-		if (pi_cond_signal(&p->c) != 0) {
+		if (pi_cond_signal(&p->c, &p->m) != 0) {
 			puts("child: cond_signal failed");
 			kill(getppid(), SIGKILL);
 			exit(1);
@@ -130,7 +130,7 @@ static int do_test(void)
 	}
 
 	do
-		pi_cond_wait(&p->c);
+		pi_cond_wait(&p->c, &p->m);
 	while (p->var != 0);
 
 	if (TEMP_FAILURE_RETRY(waitpid(pid, NULL, 0)) != pid) {

--- a/tests/glibc-tests/tst-cond16.c
+++ b/tests/glibc-tests/tst-cond16.c
@@ -27,7 +27,7 @@
 #include "rtpi.h"
 
 DEFINE_PI_MUTEX(lock, 0);
-DEFINE_PI_COND(cv, &lock, 0);
+DEFINE_PI_COND(cv, 0);
 bool n, exiting;
 FILE *f;
 enum { count = 8 };		/* Number of worker threads.  */
@@ -39,7 +39,7 @@ void *tf(void *dummy)
 	while (loop) {
 		pi_mutex_lock(&lock);
 		while (n && !exiting)
-			pi_cond_wait(&cv);
+			pi_cond_wait(&cv, &lock);
 		n = true;
 		pi_mutex_unlock(&lock);
 
@@ -50,7 +50,7 @@ void *tf(void *dummy)
 		if (exiting)
 			loop = false;
 
-		pi_cond_broadcast(&cv);
+		pi_cond_broadcast(&cv, &lock);
 		pi_mutex_unlock(&lock);
 	}
 

--- a/tests/glibc-tests/tst-cond18.c
+++ b/tests/glibc-tests/tst-cond18.c
@@ -28,7 +28,7 @@
 #include "rtpi.h"
 
 DEFINE_PI_MUTEX(lock, 0);
-DEFINE_PI_COND(cv, &lock, 0);
+DEFINE_PI_COND(cv, 0);
 bool exiting;
 int fd, spins, nn;
 enum { count = 8 };		/* Number of worker threads.  */
@@ -47,17 +47,17 @@ void *tf(void *id)
 			int njobs = rand() % (count + 1);
 			nn = njobs;
 			if ((rand() % 30) == 0)
-				pi_cond_broadcast(&cv);
+				pi_cond_broadcast(&cv, &lock);
 			else
 				while (njobs--)
-					pi_cond_signal(&cv);
+					pi_cond_signal(&cv, &lock);
 		}
 
-		pi_cond_broadcast(&cv);
+		pi_cond_broadcast(&cv, &lock);
 	} else {
 		while (!exiting) {
 			while (!nn && !exiting)
-				pi_cond_wait(&cv);
+				pi_cond_wait(&cv, &lock);
 			--nn;
 			pi_mutex_unlock(&lock);
 

--- a/tests/glibc-tests/tst-cond19.c
+++ b/tests/glibc-tests/tst-cond19.c
@@ -25,7 +25,7 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 
 static int do_test(void)
 {
@@ -39,7 +39,7 @@ static int do_test(void)
 
 	ts.tv_nsec = -1;
 
-	int e = pi_cond_timedwait(&cond, &ts);
+	int e = pi_cond_timedwait(&cond, &mut, &ts);
 	if (e == 0) {
 		puts("first cond_timedwait did not fail");
 		result = 1;
@@ -50,7 +50,7 @@ static int do_test(void)
 
 	ts.tv_nsec = 2000000000;
 
-	e = pi_cond_timedwait(&cond, &ts);
+	e = pi_cond_timedwait(&cond, &mut, &ts);
 	if (e == 0) {
 		puts("second cond_timedwait did not fail");
 		result = 1;

--- a/tests/glibc-tests/tst-cond2.c
+++ b/tests/glibc-tests/tst-cond2.c
@@ -23,7 +23,7 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 static pthread_barrier_t bar;
 
 static void *tf(void *a)
@@ -47,7 +47,7 @@ static void *tf(void *a)
 
 	printf("child %d: wait\n", i);
 
-	err = pi_cond_wait(&cond);
+	err = pi_cond_wait(&cond, &mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "child %d: failed to wait", i);
 
@@ -121,7 +121,7 @@ static int do_test(void)
 	puts("broadcast");
 
 	/* Wake up all threads.  */
-	err = pi_cond_broadcast(&cond);
+	err = pi_cond_broadcast(&cond, &mut);
 	if (err != 0)
 		error(EXIT_FAILURE, err, "parent: broadcast failed");
 

--- a/tests/glibc-tests/tst-cond22.c
+++ b/tests/glibc-tests/tst-cond22.c
@@ -6,7 +6,7 @@
 
 static pthread_barrier_t b;
 static DEFINE_PI_MUTEX(m, 0);
-static DEFINE_PI_COND(c, &m, 0);
+static DEFINE_PI_COND(c, 0);
 
 static void cl(void *arg)
 {
@@ -30,7 +30,7 @@ static void *tf(void *arg)
 	   on the mutex.  In this case the beginning of the second cond_wait
 	   call will cause the cancellation to happen.  */
 	do
-		if (pi_cond_wait(&c) != 0) {
+		if (pi_cond_wait(&c, &m) != 0) {
 			printf("%s: cond_wait failed\n", __func__);
 			exit(1);
 		}
@@ -66,7 +66,7 @@ static int do_test(void)
 		puts("1st mutex_lock failed");
 		return 1;
 	}
-	if (pi_cond_signal(&c) != 0) {
+	if (pi_cond_signal(&c, &m) != 0) {
 		puts("1st cond_signal failed");
 		return 1;
 	}
@@ -101,7 +101,7 @@ static int do_test(void)
 		puts("2nd mutex_lock failed");
 		return 1;
 	}
-	if (pi_cond_signal(&c) != 0) {
+	if (pi_cond_signal(&c, &m) != 0) {
 		puts("2nd cond_signal failed");
 		return 1;
 	}

--- a/tests/glibc-tests/tst-cond24.c
+++ b/tests/glibc-tests/tst-cond24.c
@@ -58,7 +58,7 @@ void *thread_fun_timed(void *arg)
 			struct timespec ts;
 			clock_gettime(CLOCK_MONOTONIC, &ts);
 			ts.tv_sec += 20;
-			rv = pi_cond_timedwait(&cond, &ts);
+			rv = pi_cond_timedwait(&cond, &mutex, &ts);
 
 			/* There should be no timeout either.  */
 			if (rv) {
@@ -103,7 +103,7 @@ void *thread_fun(void *arg)
 		}
 
 		while (!pending) {
-			rv = pi_cond_wait(&cond);
+			rv = pi_cond_wait(&cond, &mutex);
 
 			if (rv) {
 				printf("pi_cond_wait: %s(%d)\n",
@@ -145,7 +145,7 @@ static int do_test_wait(threadfunc f)
 		return 1;
 	}
 
-	rv = pi_cond_init(&cond, &mutex, 0);
+	rv = pi_cond_init(&cond, 0);
 	if (rv) {
 		printf("pi_cond_init: %s(%d)\n", strerror(rv), rv);
 		return 1;
@@ -172,7 +172,7 @@ static int do_test_wait(threadfunc f)
 			printf("counter: %d\n", counter);
 		pending += 1;
 
-		rv = pi_cond_signal(&cond);
+		rv = pi_cond_signal(&cond, &mutex);
 		if (rv) {
 			printf("pi_cond_signal: %s(%d)\n", strerror(rv),
 			       rv);

--- a/tests/glibc-tests/tst-cond25.c
+++ b/tests/glibc-tests/tst-cond25.c
@@ -65,7 +65,7 @@ void *signaller(void *u)
 			       strerror(ret));
 			goto out;
 		}
-		if ((ret = pi_cond_signal(&cond)) != 0) {
+		if ((ret = pi_cond_signal(&cond, &mutex)) != 0) {
 			tret = (void *)1;
 			printf("signaller:signal failed: %s\n", strerror(ret));
 			goto unlock_out;
@@ -103,7 +103,7 @@ void *waiter(void *u)
 		}
 		pthread_cleanup_push(cleanup, NULL);
 
-		if ((ret = pi_cond_wait(&cond)) != 0) {
+		if ((ret = pi_cond_wait(&cond, &mutex)) != 0) {
 			tret = (void *)(uintptr_t) 1;
 			printf("waiter[%u]:wait failed: %s\n", seq,
 			       strerror(ret));
@@ -155,7 +155,7 @@ void *timed_waiter(void *u)
 		pthread_cleanup_push(cleanup, NULL);
 
 		/* We should not time out either.  */
-		if ((ret = pi_cond_timedwait(&cond, &ts)) != 0) {
+		if ((ret = pi_cond_timedwait(&cond, &mutex, &ts)) != 0) {
 			tret = (void *)(uintptr_t) 1;
 			printf("waiter[%u]:timedwait failed: %s\n", seq,
 			       strerror(ret));
@@ -194,7 +194,7 @@ int do_test_wait(thr_func f)
 			goto out;
 		}
 
-		if ((ret = pi_cond_init(&cond, &mutex, 0)) != 0) {
+		if ((ret = pi_cond_init(&cond, 0)) != 0) {
 			printf("cond_init failed: %s\n", strerror(ret));
 			goto out;
 		}

--- a/tests/glibc-tests/tst-cond3.c
+++ b/tests/glibc-tests/tst-cond3.c
@@ -31,7 +31,7 @@ static int do_test(void);
    are added.  This is a reasonable demand.  */
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 
 #define N 10
 
@@ -48,7 +48,7 @@ static void *tf(void *arg)
 	}
 
 	/* This call should never return.  */
-	err = pi_cond_wait(&cond);
+	err = pi_cond_wait(&cond, &mut);
 	if (err != 0) {
 		printf("child %d pi_cond_wait failed to wait: %s\n",
 		       i, strerror(err));
@@ -97,7 +97,7 @@ static int do_test(void)
 	delayed_exit(1);
 
 	/* This call should never return.  */
-	err = pi_cond_wait(&cond);
+	err = pi_cond_wait(&cond, &mut);
 	if (err != 0) {
 		puts("error: pi_cond_wait in do_test failed to wait");
 		return 1;

--- a/tests/glibc-tests/tst-cond4.c
+++ b/tests/glibc-tests/tst-cond4.c
@@ -88,7 +88,7 @@ static int do_test(void)
 		return 1;
 	}
 
-	if (pi_cond_init(cond, mut2, RTPI_COND_PSHARED) != 0) {
+	if (pi_cond_init(cond, RTPI_COND_PSHARED) != 0) {
 		puts("cond_init failed");
 		return 1;
 	}
@@ -115,7 +115,7 @@ static int do_test(void)
 		}
 
 		do
-			if (pi_cond_wait(cond) != 0) {
+			if (pi_cond_wait(cond, mut2) != 0) {
 				puts("child: cond_wait failed");
 				return 1;
 			}
@@ -140,7 +140,7 @@ static int do_test(void)
 			return 1;
 		}
 
-		if (pi_cond_signal(cond) != 0) {
+		if (pi_cond_signal(cond, mut2) != 0) {
 			puts("parent: cond_signal failed");
 			return 1;
 		}

--- a/tests/glibc-tests/tst-cond5.c
+++ b/tests/glibc-tests/tst-cond5.c
@@ -26,7 +26,7 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 
 static int do_test(void)
 {
@@ -51,7 +51,7 @@ static int do_test(void)
 		ts.tv_nsec -= 1000000000;
 		++ts.tv_sec;
 	}
-	err = pi_cond_timedwait(&cond, &ts);
+	err = pi_cond_timedwait(&cond, &mut, &ts);
 	if (err == 0) {
 		/* This could in theory happen but here without any signal and
 		   additional waiter it should not.  */

--- a/tests/glibc-tests/tst-cond6.c
+++ b/tests/glibc-tests/tst-cond6.c
@@ -89,7 +89,7 @@ static int do_test(void)
 		exit(1);
 	}
 
-	if (pi_cond_init(cond, mut2, RTPI_COND_PSHARED) != 0) {
+	if (pi_cond_init(cond, RTPI_COND_PSHARED) != 0) {
 		puts("cond_init failed");
 		exit(1);
 	}
@@ -129,7 +129,7 @@ static int do_test(void)
 		}
 
 		do
-			if (pi_cond_timedwait(cond, &ts) != 0) {
+			if (pi_cond_timedwait(cond, mut2, &ts) != 0) {
 				puts("child: cond_wait failed");
 				exit(1);
 			}
@@ -154,7 +154,7 @@ static int do_test(void)
 			exit(1);
 		}
 
-		if (pi_cond_signal(cond) != 0) {
+		if (pi_cond_signal(cond, mut2) != 0) {
 			puts("parent: cond_signal failed");
 			exit(1);
 		}

--- a/tests/glibc-tests/tst-cond7.c
+++ b/tests/glibc-tests/tst-cond7.c
@@ -54,12 +54,12 @@ static void *tf(void *arg)
 
 	done = true;
 
-	if (pi_cond_signal(&t->cond) != 0) {
+	if (pi_cond_signal(&t->cond, &t->lock) != 0) {
 		puts("child: cond_signal failed");
 		exit(1);
 	}
 
-	if (pi_cond_wait(&t->cond) != 0) {
+	if (pi_cond_wait(&t->cond, &t->lock) != 0) {
 		puts("child: cond_wait failed");
 		exit(1);
 	}
@@ -87,7 +87,7 @@ static int do_test(void)
 		}
 
 		if (pi_mutex_init(&t[i]->lock, 0) != 0
-		    || pi_cond_init(&t[i]->cond, &t[i]->lock, 0) != 0) {
+		    || pi_cond_init(&t[i]->cond, 0) != 0) {
 			puts("an _init function failed");
 			exit(1);
 		}
@@ -105,7 +105,7 @@ static int do_test(void)
 		}
 
 		do
-			if (pi_cond_wait(&t[i]->cond) != 0) {
+			if (pi_cond_wait(&t[i]->cond,  &t[i]->lock) != 0) {
 				puts("cond_wait failed");
 				exit(1);
 			}

--- a/tests/glibc-tests/tst-cond8.c
+++ b/tests/glibc-tests/tst-cond8.c
@@ -25,7 +25,7 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 static pthread_barrier_t bar;
 
 static void ch(void *arg)
@@ -75,7 +75,7 @@ static void *tf1(void *p)
 
 	pthread_cleanup_push(ch, NULL);
 
-	pi_cond_wait(&cond);
+	pi_cond_wait(&cond, &mut);
 
 	pthread_cleanup_pop(0);
 
@@ -118,7 +118,7 @@ static void *tf2(void *p)
 	}
 	ts.tv_sec += 1000;
 
-	pi_cond_timedwait(&cond, &ts);
+	pi_cond_timedwait(&cond, &mut, &ts);
 
 	pthread_cleanup_pop(0);
 

--- a/tests/glibc-tests/tst-cond9.c
+++ b/tests/glibc-tests/tst-cond9.c
@@ -25,11 +25,11 @@
 #include "rtpi.h"
 
 static DEFINE_PI_MUTEX(mut, 0);
-static DEFINE_PI_COND(cond, &mut, 0);
+static DEFINE_PI_COND(cond, 0);
 
 static void *tf(void *arg)
 {
-	int err = pi_cond_wait(&cond);
+	int err = pi_cond_wait(&cond, &mut);
 	if (err == 0) {
 		puts("cond_wait did not fail");
 		exit(1);
@@ -48,7 +48,7 @@ static void *tf(void *arg)
 	}
 	ts.tv_sec += 1000;
 
-	err = pi_cond_timedwait(&cond, &ts);
+	err = pi_cond_timedwait(&cond, &mut, &ts);
 	if (err == 0) {
 		puts("cond_timedwait did not fail");
 		exit(1);
@@ -70,7 +70,7 @@ static int do_test(void)
 
 	printf("&cond = %p\n&mut = %p\n", &cond, &mut);
 
-	err = pi_cond_wait(&cond);
+	err = pi_cond_wait(&cond, &mut);
 	if (err == 0) {
 		puts("cond_wait did not fail");
 		exit(1);
@@ -89,7 +89,7 @@ static int do_test(void)
 	}
 	ts.tv_sec += 1000;
 
-	err = pi_cond_timedwait(&cond, &ts);
+	err = pi_cond_timedwait(&cond, &mut, &ts);
 	if (err == 0) {
 		puts("cond_timedwait did not fail");
 		exit(1);

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv)
 		goto out;
 	}
 
-	ret = pi_cond_init(cond, mutex, 0x0);
+	ret = pi_cond_init(cond, 0x0);
 	if (ret) {
 		printf("ERROR: pi_cond_init returned %d\n", ret);
 		goto out;

--- a/tests/tst-cond1.c
+++ b/tests/tst-cond1.c
@@ -44,7 +44,7 @@ static void *low_tf (void *p)
 	if (err != 0)
 		error (EXIT_FAILURE, err, "T%d: failed to lock m1\n", num);
 
-	err = pi_cond_wait (sig1);
+	err = pi_cond_wait (sig1, m1);
 	if (err != 0)
 		error (EXIT_FAILURE, err, "T%d: cond_wait failed on sig1\n", num);
 
@@ -74,7 +74,7 @@ static int do_test (void)
 	if (err != 0)
 		error (EXIT_FAILURE, err, "parent: failed to init mutex m1");
 
-	err = pi_cond_init (sig1, m1, 0);
+	err = pi_cond_init (sig1, 0);
 	if (err != 0)
 		error (EXIT_FAILURE, err, "parent: failed to init cond sig1");
 
@@ -88,12 +88,12 @@ static int do_test (void)
 	for (i = 0; i < 2; i++) {
 		sleep (1);
 		printf("Sig %d\n", i);
-		err = pi_cond_signal (sig1);
+		err = pi_cond_signal (sig1, m1);
 		if (err != 0)
 			error (EXIT_FAILURE, err, "parent: failed to signal condition");
 	}
 	printf("BROAD\n");
-	err = pi_cond_broadcast (sig1);
+	err = pi_cond_broadcast (sig1, m1);
 
 	for (i = 0; i < 20; i++) {
 		err = pthread_join (tthread[i], NULL);


### PR DESCRIPTION
As described in issue #22 the current API breaks down for for process shared condvar use cases. Fix this by changing the API to pass in the associated mutex where it is needed instead of at init time.