### PR TITLE
Add a C++ API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: C
 os: linux
 dist: xenial
 before_install:
+  - sudo apt-get -y install autoconf-archive
   - autoreconf --install

--- a/README.md
+++ b/README.md
@@ -139,7 +139,25 @@ Defines and initializes a PI aware mutex.
 Defines and initializes a PI aware conditional variable.
 
 # C++ Specification
-WRITEME - after the C Specification is complete
+
+## Source files
+* rtpi/mutex.hpp
+* rtpi/condition_variable.hpp
+
+## Types
+### rtpi::mutex
+
+Wrapper around the rtpi `pi_mutex_t` that is intended to work as a
+replacement for [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex).
+
+### rtpi::condition_variable
+
+Wrapper around the rtpi `pi_cond_t` that is intended to work mostly as a
+drop-in replacement for [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable).
+
+Notable differences from `std::condition_variable`:
+* `std::unique_lock<rtpi::mutex>` is used for the wait methods instead of `std::unique_lock<std::mutex>`
+* `notify_one` and `notify_all` require a `std::unique_lock<rtpi::mutex>` parameter
 
 # References
 1. POSIX pthread API?

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_PROG_AR
 LT_INIT
 AC_PROG_CC
+AC_PROG_CXX
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
  Makefile
@@ -13,4 +14,5 @@ AC_CONFIG_FILES([
  tests/glibc-tests/Makefile
 ])
 AC_CONFIG_MACRO_DIRS([m4])
+AX_CXX_COMPILE_STDCXX_11
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_CONFIG_FILES([
  src/Makefile
  tests/Makefile
  tests/glibc-tests/Makefile
+ tests/libstdc++-tests/Makefile
 ])
 AC_CONFIG_MACRO_DIRS([m4])
 AX_CXX_COMPILE_STDCXX_11

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,4 +3,9 @@
 
 lib_LTLIBRARIES = librtpi.la
 librtpi_la_SOURCES = pi_futex.h pi_mutex.c pi_cond.c
-include_HEADERS = rtpi.h rtpi_internal.h
+nobase_include_HEADERS = \
+	rtpi.h \
+	rtpi_internal.h \
+	rtpi/condition_variable.hpp \
+	rtpi/mutex.hpp
+

--- a/src/pi_cond.c
+++ b/src/pi_cond.c
@@ -52,7 +52,7 @@ int pi_cond_destroy(pi_cond_t *cond)
 }
 
 int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
-		      const struct timespec *restrict abstime)
+		      const struct timespec *abstime)
 {
 	int ret;
 	__u32 wait_id;

--- a/src/pi_futex.h
+++ b/src/pi_futex.h
@@ -23,7 +23,7 @@ static inline __u32 get_op(__u32 op, __u32 mod)
  * @val3:	varies by op
  */
 static inline int sys_futex(__u32 *uaddr, int op, __u32 val,
-			    const struct timespec *restrict utime,
+			    const struct timespec *utime,
 			    __u32 *uaddr2, __u32 val3)
 {
 	return syscall(SYS_futex, uaddr, op, val, utime, uaddr2, val3);
@@ -65,7 +65,7 @@ static inline int futex_unlock_pi(pi_mutex_t *mutex)
  * @mutex: PI mutex containing PI futex target
  */
 static inline int futex_wait_requeue_pi(pi_cond_t *cond, __u32 val,
-					const struct timespec *restrict utime,
+					const struct timespec *utime,
 					pi_mutex_t *mutex)
 {
 	return sys_futex(&cond->cond,

--- a/src/rtpi.h
+++ b/src/rtpi.h
@@ -59,7 +59,7 @@ int pi_cond_destroy(pi_cond_t *cond);
 int pi_cond_wait(pi_cond_t *cond, pi_mutex_t *mutex);
 
 int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
-		      const struct timespec *restrict abstime);
+		      const struct timespec *abstime);
 
 int pi_cond_signal(pi_cond_t *cond, pi_mutex_t *mutex);
 

--- a/src/rtpi.h
+++ b/src/rtpi.h
@@ -12,6 +12,10 @@
 
 #include "rtpi_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef union pi_mutex pi_mutex_t;
 typedef union pi_cond pi_cond_t;
 
@@ -64,5 +68,9 @@ int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
 int pi_cond_signal(pi_cond_t *cond, pi_mutex_t *mutex);
 
 int pi_cond_broadcast(pi_cond_t *cond, pi_mutex_t *mutex);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif // RTPI_H

--- a/src/rtpi/.clang-format
+++ b/src/rtpi/.clang-format
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# clang-format configuration file. Intended for clang-format >= 4.
+#
+# For more information, see:
+#
+#   Documentation/process/clang-format.rst
+#   https://clang.llvm.org/docs/ClangFormat.html
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+#AlignEscapedNewlines: Left # Unknown to clang-format-4.0
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  #AfterExternBlock: false # Unknown to clang-format-5.0
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  #SplitEmptyFunction: true # Unknown to clang-format-4.0
+  #SplitEmptyRecord: true # Unknown to clang-format-4.0
+  #SplitEmptyNamespace: true # Unknown to clang-format-4.0
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+#BreakBeforeInheritanceComma: false # Unknown to clang-format-4.0
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+#BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+#CompactNamespaces: false # Unknown to clang-format-4.0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+#FixNamespaceComments: false # Unknown to clang-format-4.0
+
+# Taken from:
+#   git grep -h '^#define [^[:space:]]*for_each[^[:space:]]*(' include/ \
+#   | sed "s,^#define \([^[:space:]]*for_each[^[:space:]]*\)(.*$,  - '\1'," \
+#   | sort | uniq
+ForEachMacros:
+  - 'apei_estatus_for_each_section'
+  - 'ata_for_each_dev'
+  - 'ata_for_each_link'
+  - '__ata_qc_for_each'
+  - 'ata_qc_for_each'
+  - 'ata_qc_for_each_raw'
+  - 'ata_qc_for_each_with_internal'
+  - 'ax25_for_each'
+  - 'ax25_uid_for_each'
+  - '__bio_for_each_bvec'
+  - 'bio_for_each_bvec'
+  - 'bio_for_each_bvec_all'
+  - 'bio_for_each_integrity_vec'
+  - '__bio_for_each_segment'
+  - 'bio_for_each_segment'
+  - 'bio_for_each_segment_all'
+  - 'bio_list_for_each'
+  - 'bip_for_each_vec'
+  - 'bitmap_for_each_clear_region'
+  - 'bitmap_for_each_set_region'
+  - 'blkg_for_each_descendant_post'
+  - 'blkg_for_each_descendant_pre'
+  - 'blk_queue_for_each_rl'
+  - 'bond_for_each_slave'
+  - 'bond_for_each_slave_rcu'
+  - 'bpf_for_each_spilled_reg'
+  - 'btree_for_each_safe128'
+  - 'btree_for_each_safe32'
+  - 'btree_for_each_safe64'
+  - 'btree_for_each_safel'
+  - 'card_for_each_dev'
+  - 'cgroup_taskset_for_each'
+  - 'cgroup_taskset_for_each_leader'
+  - 'cpufreq_for_each_entry'
+  - 'cpufreq_for_each_entry_idx'
+  - 'cpufreq_for_each_valid_entry'
+  - 'cpufreq_for_each_valid_entry_idx'
+  - 'css_for_each_child'
+  - 'css_for_each_descendant_post'
+  - 'css_for_each_descendant_pre'
+  - 'device_for_each_child_node'
+  - 'displayid_iter_for_each'
+  - 'dma_fence_chain_for_each'
+  - 'do_for_each_ftrace_op'
+  - 'drm_atomic_crtc_for_each_plane'
+  - 'drm_atomic_crtc_state_for_each_plane'
+  - 'drm_atomic_crtc_state_for_each_plane_state'
+  - 'drm_atomic_for_each_plane_damage'
+  - 'drm_client_for_each_connector_iter'
+  - 'drm_client_for_each_modeset'
+  - 'drm_connector_for_each_possible_encoder'
+  - 'drm_for_each_bridge_in_chain'
+  - 'drm_for_each_connector_iter'
+  - 'drm_for_each_crtc'
+  - 'drm_for_each_crtc_reverse'
+  - 'drm_for_each_encoder'
+  - 'drm_for_each_encoder_mask'
+  - 'drm_for_each_fb'
+  - 'drm_for_each_legacy_plane'
+  - 'drm_for_each_plane'
+  - 'drm_for_each_plane_mask'
+  - 'drm_for_each_privobj'
+  - 'drm_mm_for_each_hole'
+  - 'drm_mm_for_each_node'
+  - 'drm_mm_for_each_node_in_range'
+  - 'drm_mm_for_each_node_safe'
+  - 'flow_action_for_each'
+  - 'for_each_acpi_dev_match'
+  - 'for_each_active_dev_scope'
+  - 'for_each_active_drhd_unit'
+  - 'for_each_active_iommu'
+  - 'for_each_aggr_pgid'
+  - 'for_each_available_child_of_node'
+  - 'for_each_bio'
+  - 'for_each_board_func_rsrc'
+  - 'for_each_bvec'
+  - 'for_each_card_auxs'
+  - 'for_each_card_auxs_safe'
+  - 'for_each_card_components'
+  - 'for_each_card_dapms'
+  - 'for_each_card_pre_auxs'
+  - 'for_each_card_prelinks'
+  - 'for_each_card_rtds'
+  - 'for_each_card_rtds_safe'
+  - 'for_each_card_widgets'
+  - 'for_each_card_widgets_safe'
+  - 'for_each_cgroup_storage_type'
+  - 'for_each_child_of_node'
+  - 'for_each_clear_bit'
+  - 'for_each_clear_bit_from'
+  - 'for_each_cmsghdr'
+  - 'for_each_compatible_node'
+  - 'for_each_component_dais'
+  - 'for_each_component_dais_safe'
+  - 'for_each_comp_order'
+  - 'for_each_console'
+  - 'for_each_cpu'
+  - 'for_each_cpu_and'
+  - 'for_each_cpu_not'
+  - 'for_each_cpu_wrap'
+  - 'for_each_dapm_widgets'
+  - 'for_each_dev_addr'
+  - 'for_each_dev_scope'
+  - 'for_each_dma_cap_mask'
+  - 'for_each_dpcm_be'
+  - 'for_each_dpcm_be_rollback'
+  - 'for_each_dpcm_be_safe'
+  - 'for_each_dpcm_fe'
+  - 'for_each_drhd_unit'
+  - 'for_each_dss_dev'
+  - 'for_each_dtpm_table'
+  - 'for_each_efi_memory_desc'
+  - 'for_each_efi_memory_desc_in_map'
+  - 'for_each_element'
+  - 'for_each_element_extid'
+  - 'for_each_element_id'
+  - 'for_each_endpoint_of_node'
+  - 'for_each_evictable_lru'
+  - 'for_each_fib6_node_rt_rcu'
+  - 'for_each_fib6_walker_rt'
+  - 'for_each_free_mem_pfn_range_in_zone'
+  - 'for_each_free_mem_pfn_range_in_zone_from'
+  - 'for_each_free_mem_range'
+  - 'for_each_free_mem_range_reverse'
+  - 'for_each_func_rsrc'
+  - 'for_each_hstate'
+  - 'for_each_if'
+  - 'for_each_iommu'
+  - 'for_each_ip_tunnel_rcu'
+  - 'for_each_irq_nr'
+  - 'for_each_link_codecs'
+  - 'for_each_link_cpus'
+  - 'for_each_link_platforms'
+  - 'for_each_lru'
+  - 'for_each_matching_node'
+  - 'for_each_matching_node_and_match'
+  - 'for_each_member'
+  - 'for_each_memcg_cache_index'
+  - 'for_each_mem_pfn_range'
+  - '__for_each_mem_range'
+  - 'for_each_mem_range'
+  - '__for_each_mem_range_rev'
+  - 'for_each_mem_range_rev'
+  - 'for_each_mem_region'
+  - 'for_each_migratetype_order'
+  - 'for_each_msi_entry'
+  - 'for_each_msi_entry_safe'
+  - 'for_each_net'
+  - 'for_each_net_continue_reverse'
+  - 'for_each_netdev'
+  - 'for_each_netdev_continue'
+  - 'for_each_netdev_continue_rcu'
+  - 'for_each_netdev_continue_reverse'
+  - 'for_each_netdev_feature'
+  - 'for_each_netdev_in_bond_rcu'
+  - 'for_each_netdev_rcu'
+  - 'for_each_netdev_reverse'
+  - 'for_each_netdev_safe'
+  - 'for_each_net_rcu'
+  - 'for_each_new_connector_in_state'
+  - 'for_each_new_crtc_in_state'
+  - 'for_each_new_mst_mgr_in_state'
+  - 'for_each_new_plane_in_state'
+  - 'for_each_new_private_obj_in_state'
+  - 'for_each_node'
+  - 'for_each_node_by_name'
+  - 'for_each_node_by_type'
+  - 'for_each_node_mask'
+  - 'for_each_node_state'
+  - 'for_each_node_with_cpus'
+  - 'for_each_node_with_property'
+  - 'for_each_nonreserved_multicast_dest_pgid'
+  - 'for_each_of_allnodes'
+  - 'for_each_of_allnodes_from'
+  - 'for_each_of_cpu_node'
+  - 'for_each_of_pci_range'
+  - 'for_each_old_connector_in_state'
+  - 'for_each_old_crtc_in_state'
+  - 'for_each_old_mst_mgr_in_state'
+  - 'for_each_oldnew_connector_in_state'
+  - 'for_each_oldnew_crtc_in_state'
+  - 'for_each_oldnew_mst_mgr_in_state'
+  - 'for_each_oldnew_plane_in_state'
+  - 'for_each_oldnew_plane_in_state_reverse'
+  - 'for_each_oldnew_private_obj_in_state'
+  - 'for_each_old_plane_in_state'
+  - 'for_each_old_private_obj_in_state'
+  - 'for_each_online_cpu'
+  - 'for_each_online_node'
+  - 'for_each_online_pgdat'
+  - 'for_each_pci_bridge'
+  - 'for_each_pci_dev'
+  - 'for_each_pci_msi_entry'
+  - 'for_each_pcm_streams'
+  - 'for_each_physmem_range'
+  - 'for_each_populated_zone'
+  - 'for_each_possible_cpu'
+  - 'for_each_present_cpu'
+  - 'for_each_prime_number'
+  - 'for_each_prime_number_from'
+  - 'for_each_process'
+  - 'for_each_process_thread'
+  - 'for_each_prop_codec_conf'
+  - 'for_each_prop_dai_codec'
+  - 'for_each_prop_dai_cpu'
+  - 'for_each_prop_dlc_codecs'
+  - 'for_each_prop_dlc_cpus'
+  - 'for_each_prop_dlc_platforms'
+  - 'for_each_property_of_node'
+  - 'for_each_registered_fb'
+  - 'for_each_requested_gpio'
+  - 'for_each_requested_gpio_in_range'
+  - 'for_each_reserved_mem_range'
+  - 'for_each_reserved_mem_region'
+  - 'for_each_rtd_codec_dais'
+  - 'for_each_rtd_components'
+  - 'for_each_rtd_cpu_dais'
+  - 'for_each_rtd_dais'
+  - 'for_each_set_bit'
+  - 'for_each_set_bit_from'
+  - 'for_each_set_clump8'
+  - 'for_each_sg'
+  - 'for_each_sg_dma_page'
+  - 'for_each_sg_page'
+  - 'for_each_sgtable_dma_page'
+  - 'for_each_sgtable_dma_sg'
+  - 'for_each_sgtable_page'
+  - 'for_each_sgtable_sg'
+  - 'for_each_sibling_event'
+  - 'for_each_subelement'
+  - 'for_each_subelement_extid'
+  - 'for_each_subelement_id'
+  - '__for_each_thread'
+  - 'for_each_thread'
+  - 'for_each_unicast_dest_pgid'
+  - 'for_each_vsi'
+  - 'for_each_wakeup_source'
+  - 'for_each_zone'
+  - 'for_each_zone_zonelist'
+  - 'for_each_zone_zonelist_nodemask'
+  - 'fwnode_for_each_available_child_node'
+  - 'fwnode_for_each_child_node'
+  - 'fwnode_graph_for_each_endpoint'
+  - 'gadget_for_each_ep'
+  - 'genradix_for_each'
+  - 'genradix_for_each_from'
+  - 'hash_for_each'
+  - 'hash_for_each_possible'
+  - 'hash_for_each_possible_rcu'
+  - 'hash_for_each_possible_rcu_notrace'
+  - 'hash_for_each_possible_safe'
+  - 'hash_for_each_rcu'
+  - 'hash_for_each_safe'
+  - 'hctx_for_each_ctx'
+  - 'hlist_bl_for_each_entry'
+  - 'hlist_bl_for_each_entry_rcu'
+  - 'hlist_bl_for_each_entry_safe'
+  - 'hlist_for_each'
+  - 'hlist_for_each_entry'
+  - 'hlist_for_each_entry_continue'
+  - 'hlist_for_each_entry_continue_rcu'
+  - 'hlist_for_each_entry_continue_rcu_bh'
+  - 'hlist_for_each_entry_from'
+  - 'hlist_for_each_entry_from_rcu'
+  - 'hlist_for_each_entry_rcu'
+  - 'hlist_for_each_entry_rcu_bh'
+  - 'hlist_for_each_entry_rcu_notrace'
+  - 'hlist_for_each_entry_safe'
+  - 'hlist_for_each_entry_srcu'
+  - '__hlist_for_each_rcu'
+  - 'hlist_for_each_safe'
+  - 'hlist_nulls_for_each_entry'
+  - 'hlist_nulls_for_each_entry_from'
+  - 'hlist_nulls_for_each_entry_rcu'
+  - 'hlist_nulls_for_each_entry_safe'
+  - 'i3c_bus_for_each_i2cdev'
+  - 'i3c_bus_for_each_i3cdev'
+  - 'ide_host_for_each_port'
+  - 'ide_port_for_each_dev'
+  - 'ide_port_for_each_present_dev'
+  - 'idr_for_each_entry'
+  - 'idr_for_each_entry_continue'
+  - 'idr_for_each_entry_continue_ul'
+  - 'idr_for_each_entry_ul'
+  - 'in_dev_for_each_ifa_rcu'
+  - 'in_dev_for_each_ifa_rtnl'
+  - 'inet_bind_bucket_for_each'
+  - 'inet_lhash2_for_each_icsk_rcu'
+  - 'key_for_each'
+  - 'key_for_each_safe'
+  - 'klp_for_each_func'
+  - 'klp_for_each_func_safe'
+  - 'klp_for_each_func_static'
+  - 'klp_for_each_object'
+  - 'klp_for_each_object_safe'
+  - 'klp_for_each_object_static'
+  - 'kunit_suite_for_each_test_case'
+  - 'kvm_for_each_memslot'
+  - 'kvm_for_each_vcpu'
+  - 'list_for_each'
+  - 'list_for_each_codec'
+  - 'list_for_each_codec_safe'
+  - 'list_for_each_continue'
+  - 'list_for_each_entry'
+  - 'list_for_each_entry_continue'
+  - 'list_for_each_entry_continue_rcu'
+  - 'list_for_each_entry_continue_reverse'
+  - 'list_for_each_entry_from'
+  - 'list_for_each_entry_from_rcu'
+  - 'list_for_each_entry_from_reverse'
+  - 'list_for_each_entry_lockless'
+  - 'list_for_each_entry_rcu'
+  - 'list_for_each_entry_reverse'
+  - 'list_for_each_entry_safe'
+  - 'list_for_each_entry_safe_continue'
+  - 'list_for_each_entry_safe_from'
+  - 'list_for_each_entry_safe_reverse'
+  - 'list_for_each_entry_srcu'
+  - 'list_for_each_prev'
+  - 'list_for_each_prev_safe'
+  - 'list_for_each_safe'
+  - 'llist_for_each'
+  - 'llist_for_each_entry'
+  - 'llist_for_each_entry_safe'
+  - 'llist_for_each_safe'
+  - 'mci_for_each_dimm'
+  - 'media_device_for_each_entity'
+  - 'media_device_for_each_intf'
+  - 'media_device_for_each_link'
+  - 'media_device_for_each_pad'
+  - 'nanddev_io_for_each_page'
+  - 'netdev_for_each_lower_dev'
+  - 'netdev_for_each_lower_private'
+  - 'netdev_for_each_lower_private_rcu'
+  - 'netdev_for_each_mc_addr'
+  - 'netdev_for_each_uc_addr'
+  - 'netdev_for_each_upper_dev_rcu'
+  - 'netdev_hw_addr_list_for_each'
+  - 'nft_rule_for_each_expr'
+  - 'nla_for_each_attr'
+  - 'nla_for_each_nested'
+  - 'nlmsg_for_each_attr'
+  - 'nlmsg_for_each_msg'
+  - 'nr_neigh_for_each'
+  - 'nr_neigh_for_each_safe'
+  - 'nr_node_for_each'
+  - 'nr_node_for_each_safe'
+  - 'of_for_each_phandle'
+  - 'of_property_for_each_string'
+  - 'of_property_for_each_u32'
+  - 'pci_bus_for_each_resource'
+  - 'pcl_for_each_chunk'
+  - 'pcl_for_each_segment'
+  - 'pcm_for_each_format'
+  - 'ping_portaddr_for_each_entry'
+  - 'plist_for_each'
+  - 'plist_for_each_continue'
+  - 'plist_for_each_entry'
+  - 'plist_for_each_entry_continue'
+  - 'plist_for_each_entry_safe'
+  - 'plist_for_each_safe'
+  - 'pnp_for_each_card'
+  - 'pnp_for_each_dev'
+  - 'protocol_for_each_card'
+  - 'protocol_for_each_dev'
+  - 'queue_for_each_hw_ctx'
+  - 'radix_tree_for_each_slot'
+  - 'radix_tree_for_each_tagged'
+  - 'rb_for_each'
+  - 'rbtree_postorder_for_each_entry_safe'
+  - 'rdma_for_each_block'
+  - 'rdma_for_each_port'
+  - 'rdma_umem_for_each_dma_block'
+  - 'resource_list_for_each_entry'
+  - 'resource_list_for_each_entry_safe'
+  - 'rhl_for_each_entry_rcu'
+  - 'rhl_for_each_rcu'
+  - 'rht_for_each'
+  - 'rht_for_each_entry'
+  - 'rht_for_each_entry_from'
+  - 'rht_for_each_entry_rcu'
+  - 'rht_for_each_entry_rcu_from'
+  - 'rht_for_each_entry_safe'
+  - 'rht_for_each_from'
+  - 'rht_for_each_rcu'
+  - 'rht_for_each_rcu_from'
+  - '__rq_for_each_bio'
+  - 'rq_for_each_bvec'
+  - 'rq_for_each_segment'
+  - 'scsi_for_each_prot_sg'
+  - 'scsi_for_each_sg'
+  - 'sctp_for_each_hentry'
+  - 'sctp_skb_for_each'
+  - 'shdma_for_each_chan'
+  - '__shost_for_each_device'
+  - 'shost_for_each_device'
+  - 'sk_for_each'
+  - 'sk_for_each_bound'
+  - 'sk_for_each_entry_offset_rcu'
+  - 'sk_for_each_from'
+  - 'sk_for_each_rcu'
+  - 'sk_for_each_safe'
+  - 'sk_nulls_for_each'
+  - 'sk_nulls_for_each_from'
+  - 'sk_nulls_for_each_rcu'
+  - 'snd_array_for_each'
+  - 'snd_pcm_group_for_each_entry'
+  - 'snd_soc_dapm_widget_for_each_path'
+  - 'snd_soc_dapm_widget_for_each_path_safe'
+  - 'snd_soc_dapm_widget_for_each_sink_path'
+  - 'snd_soc_dapm_widget_for_each_source_path'
+  - 'tb_property_for_each'
+  - 'tcf_exts_for_each_action'
+  - 'udp_portaddr_for_each_entry'
+  - 'udp_portaddr_for_each_entry_rcu'
+  - 'usb_hub_for_each_child'
+  - 'v4l2_device_for_each_subdev'
+  - 'v4l2_m2m_for_each_dst_buf'
+  - 'v4l2_m2m_for_each_dst_buf_safe'
+  - 'v4l2_m2m_for_each_src_buf'
+  - 'v4l2_m2m_for_each_src_buf_safe'
+  - 'virtio_device_for_each_vq'
+  - 'while_for_each_ftrace_op'
+  - 'xa_for_each'
+  - 'xa_for_each_marked'
+  - 'xa_for_each_range'
+  - 'xa_for_each_start'
+  - 'xas_for_each'
+  - 'xas_for_each_conflict'
+  - 'xas_for_each_marked'
+  - 'xbc_array_for_each_value'
+  - 'xbc_for_each_key_value'
+  - 'xbc_node_for_each_array_value'
+  - 'xbc_node_for_each_child'
+  - 'xbc_node_for_each_key_value'
+  - 'zorro_for_each_dev'
+
+#IncludeBlocks: Preserve # Unknown to clang-format-5.0
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+#IndentPPDirectives: None # Unknown to clang-format-5.0
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+#ObjCBinPackProtocolList: Auto # Unknown to clang-format-5.0
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+# Taken from git's rules
+#PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+#SortUsingDeclarations: false # Unknown to clang-format-4.0
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true # Unknown to clang-format-5.0
+#SpaceBeforeInheritanceColon: true # Unknown to clang-format-5.0
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-5.0
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth: 8
+UseTab: Always
+...

--- a/src/rtpi/condition_variable.hpp
+++ b/src/rtpi/condition_variable.hpp
@@ -1,0 +1,238 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+
+#ifndef RTPI_CONDITION_VARIABLE_HPP
+#define RTPI_CONDITION_VARIABLE_HPP
+
+#include <chrono>
+#include <condition_variable>
+
+#include "rtpi.h"
+#include "rtpi/mutex.hpp"
+
+namespace rtpi
+{
+// The condition_variable class is a synchronization primitive that can be
+// used to block a thread, or multiple threads at the same time, until
+// another thread both modifies a shared variable (the condition), and
+// notifies the condition_variable.
+//
+// The API is based upon the C++ std::condition_variable API, with a
+// notable difference in that notify_one/notify_all have an additional
+// parameter for a std::unique_lock<rtpi::mutex>.
+//
+// rtpi::condition_variable works only with std::unique_lock<rtpi::mutex>.
+//
+
+using std::cv_status;
+
+class condition_variable {
+    private:
+	pi_cond_t c;
+
+    public:
+	typedef pi_cond_t *native_handle_type;
+
+	// Constructs the condition_variable. The condition_variable is in unlocked state after the constructor completes.
+	constexpr condition_variable() noexcept : c(PI_COND_INIT(0))
+	{
+	}
+
+	// Copy constructor is deleted.
+	condition_variable(const condition_variable &) = delete;
+
+	// Destroys the condition_variable.
+	~condition_variable()
+	{
+		pi_cond_destroy(&c);
+	}
+
+	// Not copy-assignable.
+	const condition_variable &
+	operator=(const condition_variable &) = delete;
+
+	// If any threads are waiting on *this, calling notify_one unblocks one of the waiting threads.
+	void notify_one(std::unique_lock<rtpi::mutex> &lock) noexcept
+	{
+		pi_cond_signal(&c, lock.mutex()->native_handle());
+	}
+
+	// Unblocks all threads currently waiting for *this.
+	void notify_all(std::unique_lock<rtpi::mutex> &lock) noexcept
+	{
+		pi_cond_broadcast(&c, lock.mutex()->native_handle());
+	}
+
+	// Atomically unlocks lock, blocks the current executing thread, and
+	// adds it to the list of threads waiting on *this. The thread will be
+	// unblocked when notify_all() or notify_one() is executed. It may
+	// also be unblocked spuriously. When unblocked, regardless of the
+	// reason, lock is reacquired and wait exits.
+	void wait(std::unique_lock<rtpi::mutex> &lock)
+	{
+		int e = pi_cond_wait(&c, lock.mutex()->native_handle());
+
+		if (e)
+			std::terminate();
+	}
+
+	// Overload that takes a predicate. This overload may be used to
+	// ignore spurious awakenings while waiting for a specific condition
+	// to become true.
+	template <class Predicate>
+	void wait(std::unique_lock<rtpi::mutex> &lock, Predicate stop_waiting)
+	{
+		while (!stop_waiting()) {
+			wait(lock);
+		}
+	}
+
+	// Atomically releases lock, blocks the current executing thread, and
+	// adds it to the list of threads waiting on *this. The thread will be
+	// unblocked when notify_all() or notify_one() is executed, or when
+	// the relative timeout rel_time expires. It may also be unblocked
+	// spuriously. When unblocked, regardless of the reason, lock is
+	// reacquired and wait_for() exits.
+	template <class Clock, class Period>
+	cv_status wait_for(std::unique_lock<rtpi::mutex> &lock,
+			   const std::chrono::duration<Clock, Period> &rel_time)
+	{
+		using duration = std::chrono::steady_clock::duration;
+
+		// When converting from a floating-point rel_time to the
+		// (integer) steady_clock duration type, the loss of precision
+		// may result in the time being rounded down, so round it
+		// back up if necessary.
+		auto relative_time =
+			std::chrono::duration_cast<duration>(rel_time);
+		if (relative_time < rel_time)
+			++relative_time;
+
+		return wait_until(lock, std::chrono::steady_clock::now() +
+						relative_time);
+	}
+
+	// Overload that takes a predicate. This overload may be used to
+	// ignore spurious awakenings while waiting for a specific condition
+	// to become true.
+	template <class Clock, class Period, class Predicate>
+	bool wait_for(std::unique_lock<rtpi::mutex> &lock,
+		      const std::chrono::duration<Clock, Period> &rel_time,
+		      Predicate stop_waiting)
+	{
+		using duration = std::chrono::steady_clock::duration;
+
+		// If the conversion requires it, round up.
+		auto relative_time =
+			std::chrono::duration_cast<duration>(rel_time);
+		if (relative_time < rel_time)
+			++relative_time;
+
+		return wait_until(
+			lock, std::chrono::steady_clock::now() + relative_time,
+			std::move(stop_waiting));
+	}
+
+	// Atomically releases lock, blocks the current executing thread, and
+	// adds it to the list of threads waiting on *this. The thread will be
+	// unblocked when notify_all() or notify_one() is executed, or when
+	// the absolute time point timeout_time is reached. It may also be
+	// unblocked spuriously. When unblocked, regardless of the reason,
+	// lock is reacquired and wait_until exits.
+	template <class Duration>
+	cv_status
+	wait_until(std::unique_lock<rtpi::mutex> &lock,
+		   const std::chrono::time_point<std::chrono::steady_clock,
+						 Duration> &timeout_time)
+	{
+		return wait_until_impl(lock, timeout_time);
+	}
+
+	template <class Clock, class Duration>
+	cv_status
+	wait_until(std::unique_lock<rtpi::mutex> &lock,
+		   const std::chrono::time_point<Clock, Duration> &timeout_time)
+	{
+		using std::chrono::steady_clock;
+
+		const typename Clock::time_point user_clock_entry =
+			Clock::now();
+		const typename steady_clock::time_point steady_clock_entry =
+			steady_clock::now();
+
+		const auto delta = timeout_time - user_clock_entry;
+		const auto steady_timeout_time = steady_clock_entry + delta;
+
+		if (wait_until_impl(lock, steady_timeout_time) ==
+		    cv_status::no_timeout) {
+			return cv_status::no_timeout;
+		}
+
+		// We got a timeout against CLOCK_MONOTONIC but we need to check
+		// against the caller-supplied clock.
+		if (Clock::now() < timeout_time) {
+			return cv_status::no_timeout;
+		}
+
+		return cv_status::timeout;
+	}
+
+	// Overload that takes a predicate. This overload may be used to
+	// ignore spurious awakenings while waiting for a specific condition
+	// to become true.
+	template <class Clock, class Duration, class Predicate>
+	bool
+	wait_until(std::unique_lock<rtpi::mutex> &lock,
+		   const std::chrono::time_point<Clock, Duration> &timeout_time,
+		   Predicate stop_waiting)
+	{
+		while (!stop_waiting) {
+			if (wait_until(lock, timeout_time) ==
+			    cv_status::timeout)
+				return stop_waiting();
+		}
+
+		return true;
+	}
+
+	// Returns the underlying implementation-defined native handle object.
+	//
+	// for librtpi, this is a pi_cond_t*.
+	native_handle_type native_handle()
+	{
+		return &c;
+	}
+
+    private:
+	template <class Duration>
+	cv_status
+	wait_until_impl(std::unique_lock<rtpi::mutex> &lock,
+			const std::chrono::time_point<std::chrono::steady_clock,
+						      Duration> &timeout_time)
+	{
+		auto s = std::chrono::time_point_cast<std::chrono::seconds>(
+			timeout_time);
+		auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+			timeout_time - s);
+
+		struct timespec ts = { static_cast<std::time_t>(
+					       s.time_since_epoch().count()),
+				       static_cast<long>(ns.count()) };
+
+		// pi_cond_timedwait uses CLOCK_MONOTONIC (steady_clock)
+		int e = pi_cond_timedwait(&c, lock.mutex()->native_handle(),
+					  &ts);
+
+		if (e == 0) {
+			return cv_status::no_timeout;
+		} else if (e == ETIMEDOUT) {
+			return cv_status::timeout;
+		} else {
+			throw std::system_error(
+				std::error_code(e, std::generic_category()));
+		}
+	}
+};
+
+} // namespace rtpi
+
+#endif

--- a/src/rtpi/mutex.hpp
+++ b/src/rtpi/mutex.hpp
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+
+#ifndef RTPI_MUTEX_HPP
+#define RTPI_MUTEX_HPP
+
+#include <mutex>
+#include <system_error>
+
+#include "rtpi.h"
+
+namespace rtpi
+{
+// The mutex class is a synchronization primitive that can be used to protect
+// shared data from being simultaneously accessed by multiple threads.
+//
+// The API is based on the C++ std::mutex API.
+//
+// The mutex class satisfies the Mutex named requirement.
+
+class mutex {
+    private:
+	pi_mutex m;
+
+    public:
+	typedef pi_mutex *native_handle_type;
+
+	// Constructs the mutex. The mutex is in unlocked state after the constructor completes.
+	constexpr mutex() noexcept : m(PI_MUTEX_INIT(0))
+	{
+	}
+
+	// Copy constructor is deleted.
+	mutex(const mutex &) = delete;
+
+	// Destroys the mutex.
+	~mutex()
+	{
+		pi_mutex_destroy(&m);
+	}
+
+	// Not copy-assignable.
+	const mutex &operator=(const mutex &) = delete;
+
+	// Locks the mutex. If another thread has already locked the mutex,
+	// a call to lock will block execution until the lock is acquired.
+	void lock()
+	{
+		int e = pi_mutex_lock(&m);
+
+		if (e)
+			throw std::system_error(
+				std::error_code(e, std::generic_category()));
+	}
+
+	// Tries to lock the mutex. Returns immediately. On successful lock
+	// acquisition returns true, otherwise returns false.
+	bool try_lock()
+	{
+		// can return EBUSY or EDEADLOCK
+		return !pi_mutex_trylock(&m);
+	}
+
+	// Unlocks the mutex.
+	void unlock()
+	{
+		pi_mutex_unlock(&m);
+
+		// pi_mutex_unlock might fail (EPERM, or errno from futex)
+		// but the Mutex requirement states that unlock does not
+		// throw exceptions.
+	}
+
+	// Returns the underlying implementation-defined native handle object.
+	//
+	// for librtpi, this is a pi_mutex*.
+	native_handle_type native_handle()
+	{
+		return &m;
+	}
+};
+
+} // namespace rtpi
+
+#endif

--- a/src/rtpi_internal.h
+++ b/src/rtpi_internal.h
@@ -17,7 +17,13 @@ union pi_mutex {
 	__u8 pad[64];
 } __attribute__ ((aligned(64)));
 
+#ifndef __cplusplus
 #define PI_MUTEX_INIT(f) { .futex = 0, .flags = f }
+#else
+inline constexpr pi_mutex PI_MUTEX_INIT(__u32 f) {
+	return pi_mutex{ 0, f };
+}
+#endif
 
 /*
  * PI Cond
@@ -34,6 +40,7 @@ union pi_cond {
 	__u8 pad[128];
 } __attribute__ ((aligned(64)));
 
+#ifndef __cplusplus
 #define PI_COND_INIT(f) \
 	{ .priv_mut = PI_MUTEX_INIT(f) \
 	, .cond = 0 \
@@ -41,5 +48,10 @@ union pi_cond {
 	, .wake_id = 0 \
 	, .pending_wake = 0 \
 	, .pending_wait = 0 }
+#else
+inline constexpr pi_cond PI_COND_INIT(__u32 f) {
+	return pi_cond{ PI_MUTEX_INIT(f), 0, f, 0, 0, 0 };
+}
+#endif
 
 #endif // RPTI_H_INTERNAL_H

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,5 +5,7 @@ AM_CPPFLAGS = -I. -I$(top_srcdir)/src
 LDADD = $(top_builddir)/src/librtpi.la -lpthread
 SUBDIRS = glibc-tests
 
-check_PROGRAMS = test_api tst-cond1 tst-condpi2
-TESTS = test_api tst-cond1 tst-condpi2.sh
+check_PROGRAMS = test_api tst-cond1 tst-condpi2 tst-condpi2-cpp
+TESTS = test_api tst-cond1 tst-condpi2.sh tst-condpi2-cpp.sh
+
+tst_condpi2_cpp_SOURCES = tst-condpi2-cpp.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src
 LDADD = $(top_builddir)/src/librtpi.la -lpthread
-SUBDIRS = glibc-tests
+SUBDIRS = glibc-tests libstdc++-tests
 
 check_PROGRAMS = test_api tst-cond1 tst-condpi2 tst-condpi2-cpp
 TESTS = test_api tst-cond1 tst-condpi2.sh tst-condpi2-cpp.sh

--- a/tests/libstdc++-tests/Makefile.am
+++ b/tests/libstdc++-tests/Makefile.am
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# This is a massively simplified Makefile.am for tests from the libstdc++
+# test suite that have been ported over to use librtpi primitives.
+#
+# Notably, we do not include the compile-only tests (e.g. the ones to make
+# sure that compilation fails when trying to use a deleted member, et al)
+# because trying to get the scripting (some of which is in dejagnu) over
+# here for that was more effort than it seemed worth.
+
+AUTOMAKE_OPTIONS = subdir-objects
+
+AM_CPPFLAGS = -I. -I$(top_srcdir)/src -I$(top_srcdir)/tests/libstdc++-tests/util
+LDADD = $(top_builddir)/src/librtpi.la -lpthread
+
+test_list = \
+    condition_variable/cons/1 \
+    condition_variable/members/1 \
+    condition_variable/members/2 \
+    condition_variable/members/53841 \
+    condition_variable/native_handle/typesizes \
+    condition_variable/requirements/standard_layout \
+    condition_variable/requirements/typedefs \
+    mutex/cons/1 \
+    mutex/cons/constexpr \
+    mutex/dest/destructor_locked \
+    mutex/lock/1 \
+    mutex/native_handle/1 \
+    mutex/native_handle/typesizes \
+    mutex/requirements/standard_layout \
+    mutex/requirements/typedefs \
+    mutex/try_lock/1 \
+    mutex/try_lock/2 \
+    mutex/unlock/1 \
+    mutex/unlock/2
+
+# need to support notify_all_at_thread_exit
+#    condition_variable/members/3
+
+# pi_cond_destroy needs to unblock all waiters
+#    condition_variable/54185
+
+# these ones haven't been evaluated yet
+#    condition_variable/members/68519
+#    condition_variable/members/103382
+
+AM_DEFAULT_SOURCE_EXT = .cc
+
+nobase_check_PROGRAMS = $(test_list)
+
+TESTS = $(test_list)
+
+test: check

--- a/tests/libstdc++-tests/README
+++ b/tests/libstdc++-tests/README
@@ -1,0 +1,6 @@
+The test code in this directory is originally derived from libstdc++'s
+test suite and is licensed under the GPLv3.
+
+See the upstream gcc.git for more details:
+
+https://gcc.gnu.org/git/gcc.git

--- a/tests/libstdc++-tests/condition_variable/54185.cc
+++ b/tests/libstdc++-tests/condition_variable/54185.cc
@@ -1,0 +1,60 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2012-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include <vector>
+#include "rtpi/mutex.hpp"
+#include "rtpi/condition_variable.hpp"
+#include <thread>
+
+// PR libstdc++/54185
+
+rtpi::condition_variable* cond = nullptr;
+rtpi::mutex mx;
+int started = 0;
+int constexpr NUM_THREADS = 10;
+
+void do_thread_a()
+{
+  std::unique_lock<rtpi::mutex> lock(mx);
+  if(++started >= NUM_THREADS)
+  {
+    cond->notify_all(lock);
+    delete cond;
+    cond = nullptr;
+  }
+  else
+    cond->wait(lock);
+}
+
+int main(){
+  std::vector<std::thread> vec;
+  for(int j = 0; j < 1000; ++j)
+  {
+    started = 0;
+    cond = new rtpi::condition_variable;
+    for (int i = 0; i < NUM_THREADS; ++i)
+      vec.emplace_back(&do_thread_a);
+    for (int i = 0; i < NUM_THREADS; ++i)
+      vec[i].join();
+    vec.clear();
+  }
+}

--- a/tests/libstdc++-tests/condition_variable/cons/1.cc
+++ b/tests/libstdc++-tests/condition_variable/cons/1.cc
@@ -1,0 +1,44 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/condition_variable.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  try 
+    {
+      rtpi::condition_variable c1;
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/condition_variable/members/1.cc
+++ b/tests/libstdc++-tests/condition_variable/members/1.cc
@@ -1,0 +1,57 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include "rtpi/condition_variable.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+void test01()
+{
+  try 
+    {
+      std::chrono::microseconds ms(500);
+      rtpi::condition_variable c1;
+      rtpi::mutex m;
+      std::unique_lock<rtpi::mutex> l(m);
+
+      auto then = std::chrono::system_clock::now();
+      std::cv_status result = c1.wait_for(l, ms);
+      VERIFY( result == std::cv_status::timeout );
+      VERIFY( (std::chrono::system_clock::now() - then) >= ms );
+      VERIFY( l.owns_lock() );
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+}
+
+int main()
+{
+  test01();
+  return 0;
+}

--- a/tests/libstdc++-tests/condition_variable/members/103382.cc
+++ b/tests/libstdc++-tests/condition_variable/members/103382.cc
@@ -1,0 +1,66 @@
+// { dg-options "-pthread" }
+// { dg-do run { target { *-*-linux* *-*-gnu* } } }
+// { dg-require-effective-target c++11 }
+// { dg-require-effective-target pthread }
+// { dg-require-gthreads "" }
+
+#include "rtpi/condition_variable.hpp"
+#include <chrono>
+#include "rtpi/mutex.hpp"
+#include <thread>
+
+// PR libstdc++/103382
+
+template<typename F>
+void
+test_cancel(F wait)
+{
+  rtpi::mutex m;
+  rtpi::condition_variable cv;
+  bool waiting = false;
+
+  std::thread t([&] {
+    std::unique_lock<rtpi::mutex> lock(m);
+    waiting = true;
+    wait(cv, lock); // __forced_unwind exception should not terminate process.
+  });
+
+  // Ensure the condition variable is waiting before we cancel.
+  // This shouldn't be necessary because pthread_mutex_lock is not
+  // a cancellation point, but no harm in making sure we test what
+  // we intend to test: that cancel during a wait doesn't abort.
+  while (true)
+  {
+    std::unique_lock<rtpi::mutex> lock(m);
+    if (waiting)
+      break;
+  }
+
+  pthread_cancel(t.native_handle());
+  t.join();
+}
+
+int main()
+{
+  test_cancel(
+      [](rtpi::condition_variable& cv, std::unique_lock<rtpi::mutex>& l) {
+	cv.wait(l);
+      });
+
+  test_cancel(
+      [](rtpi::condition_variable& cv, std::unique_lock<rtpi::mutex>& l) {
+	cv.wait(l, []{ return false; });
+      });
+
+  using mins = std::chrono::minutes;
+
+  test_cancel(
+      [](rtpi::condition_variable& cv, std::unique_lock<rtpi::mutex>& l) {
+	cv.wait_for(l, mins(1));
+      });
+
+  test_cancel(
+      [](rtpi::condition_variable& cv, std::unique_lock<rtpi::mutex>& l) {
+	cv.wait_until(l, std::chrono::system_clock::now() + mins(1));
+      });
+}

--- a/tests/libstdc++-tests/condition_variable/members/2.cc
+++ b/tests/libstdc++-tests/condition_variable/members/2.cc
@@ -1,0 +1,127 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include "rtpi/condition_variable.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+#include <slow_clock.h>
+
+template <typename ClockType>
+void test01()
+{
+  try 
+    {
+      std::chrono::microseconds ms(500);
+      rtpi::condition_variable c1;
+      rtpi::mutex m;
+      std::unique_lock<rtpi::mutex> l(m);
+
+      auto then = ClockType::now();
+      std::cv_status result = c1.wait_until(l, then + ms);
+      VERIFY( result == std::cv_status::timeout );
+      VERIFY( (ClockType::now() - then) >= ms );
+      VERIFY( l.owns_lock() );
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+}
+
+void test01_alternate_clock()
+{
+  using __gnu_test::slow_clock;
+
+  try
+    {
+      rtpi::condition_variable c1;
+      rtpi::mutex m;
+      std::unique_lock<rtpi::mutex> l(m);
+      auto const expire = slow_clock::now() + std::chrono::seconds(1);
+
+      while (slow_clock::now() < expire)
+       {
+         auto const result = c1.wait_until(l, expire);
+
+         // If wait_until returns before the timeout has expired when
+         // measured against the supplied clock, then wait_until must
+         // return no_timeout.
+         if (slow_clock::now() < expire)
+           VERIFY(result == std::cv_status::no_timeout);
+
+         // If wait_until returns timeout then the timeout must have
+         // expired.
+         if (result == std::cv_status::timeout)
+           VERIFY(slow_clock::now() >= expire);
+       }
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+}
+
+/* User defined clock that ticks in two-thousandths of a second
+   forty-two minutes ahead of steady_clock. */
+struct user_defined_clock
+{
+  typedef std::chrono::steady_clock::rep rep;
+  typedef std::ratio<1, 2000> period;
+  typedef std::chrono::duration<rep, period> duration;
+  typedef std::chrono::time_point<user_defined_clock> time_point;
+
+  static constexpr bool is_steady = true;
+
+  static time_point now() noexcept
+  {
+    using namespace std::chrono;
+    const auto steady_since_epoch = steady_clock::now().time_since_epoch();
+    const auto user_since_epoch = duration_cast<duration>(steady_since_epoch);
+    return time_point(user_since_epoch + minutes(42));
+  }
+};
+
+/*
+It's not possible for this test to automatically ensure that the
+system_clock test cases result in a wait on CLOCK_REALTIME and steady_clock
+test cases result in a wait on CLOCK_MONOTONIC. It's recommended to run the
+test under strace(1) and check whether the expected futex calls are made by
+glibc. See https://gcc.gnu.org/ml/libstdc++/2019-09/msg00022.html for
+instructions.
+*/
+
+int main()
+{
+  test01<std::chrono::steady_clock>();
+  test01<std::chrono::system_clock>();
+  test01<user_defined_clock>();
+  test01_alternate_clock();
+}

--- a/tests/libstdc++-tests/condition_variable/members/3.cc
+++ b/tests/libstdc++-tests/condition_variable/members/3.cc
@@ -1,0 +1,57 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2014-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rtpi/condition_variable.hpp"
+#include <thread>
+#include "rtpi/mutex.hpp"
+#include <testsuite_hooks.h>
+
+rtpi::mutex mx;
+rtpi::condition_variable cv;
+int counter = 0;
+
+struct Inc
+{
+  Inc() { ++counter; }
+  ~Inc() { ++counter; }
+};
+
+
+void func()
+{
+  std::unique_lock<rtpi::mutex> lock{mx};
+  std::notify_all_at_thread_exit(cv, std::move(lock));
+#if CORRECT_THREAD_LOCAL_DTORS
+  // Correct order of thread_local destruction needs __cxa_thread_atexit_impl
+  // or similar support from libc.
+  static thread_local
+#endif
+  Inc inc;
+}
+
+int main()
+{
+  std::unique_lock<rtpi::mutex> lock{mx};
+  std::thread t{func};
+  cv.wait(lock, [&]{ return counter == 2; });
+  t.join();
+}

--- a/tests/libstdc++-tests/condition_variable/members/53841.cc
+++ b/tests/libstdc++-tests/condition_variable/members/53841.cc
@@ -1,0 +1,53 @@
+// { dg-do compile }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2012-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+// PR libstdc++/53841
+
+#include <chrono>
+#include "rtpi/mutex.hpp"
+#include "rtpi/condition_variable.hpp"
+
+namespace ch = std::chrono;
+
+struct FPClock : ch::system_clock
+{
+    typedef double rep;
+    typedef std::ratio<1> period;
+    typedef ch::duration<rep, period> duration;
+    typedef ch::time_point<FPClock> time_point;
+
+    static time_point now()
+    { return time_point(duration(system_clock::now().time_since_epoch())); }
+};
+
+void f()
+{
+    rtpi::mutex mx;
+    std::unique_lock<rtpi::mutex> l(mx);
+    rtpi::condition_variable cv;
+    cv.wait_until(l, FPClock::now());
+}
+
+int main()
+{
+    f();
+}

--- a/tests/libstdc++-tests/condition_variable/members/68519.cc
+++ b/tests/libstdc++-tests/condition_variable/members/68519.cc
@@ -1,0 +1,97 @@
+// Copyright (C) 2017-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+#include "rtpi/condition_variable.hpp"
+#include <testsuite_hooks.h>
+
+// PR libstdc++/68519
+
+void
+test_wait_for()
+{
+  rtpi::mutex mx;
+  rtpi::condition_variable cv;
+
+  for (int i = 0; i < 3; ++i)
+  {
+    std::unique_lock<rtpi::mutex> l(mx);
+    auto start = std::chrono::system_clock::now();
+    cv.wait_for(l, std::chrono::duration<float>(1), [] { return false; });
+    auto t = std::chrono::system_clock::now();
+    VERIFY( (t - start) >= std::chrono::seconds(1) );
+  }
+}
+
+// In order to ensure that the delta calculated in the arbitrary clock overload
+// of condition_variable::wait_until fits accurately in a float, but the result
+// of adding it to steady_clock with a float duration does not, this clock
+// needs to use a more recent epoch.
+struct recent_epoch_float_clock
+{
+  using duration = std::chrono::duration<float>;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point
+    = std::chrono::time_point<recent_epoch_float_clock, duration>;
+  static constexpr bool is_steady = true;
+
+  static const std::chrono::steady_clock::time_point epoch;
+
+  static time_point now()
+  {
+    const auto steady = std::chrono::steady_clock::now();
+    return time_point{steady - epoch};
+  }
+};
+
+const std::chrono::steady_clock::time_point recent_epoch_float_clock::epoch =
+  std::chrono::steady_clock::now();
+
+void
+test_wait_until()
+{
+  using clock = recent_epoch_float_clock;
+
+  rtpi::mutex mx;
+  rtpi::condition_variable cv;
+
+  for (int i = 0; i < 3; ++i)
+  {
+    std::unique_lock<rtpi::mutex> l(mx);
+    const auto start = clock::now();
+    const auto wait_time = start + std::chrono::duration<float>{1.0};
+
+    // In theory we could get a spurious wakeup, but in practice we won't.
+    const auto result = cv.wait_until(l, wait_time);
+
+    VERIFY( result == std::cv_status::timeout );
+    const auto elapsed = clock::now() - start;
+    VERIFY( elapsed >= std::chrono::seconds(1) );
+  }
+}
+
+int
+main()
+{
+  test_wait_for();
+  test_wait_until();
+}

--- a/tests/libstdc++-tests/condition_variable/native_handle/typesizes.cc
+++ b/tests/libstdc++-tests/condition_variable/native_handle/typesizes.cc
@@ -1,0 +1,31 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rtpi/condition_variable.hpp"
+#include <thread/all.h>
+
+int main()
+{
+  typedef rtpi::condition_variable test_type;
+  __gnu_test::compare_type_to_native_type<test_type>();
+  return 0;
+}

--- a/tests/libstdc++-tests/condition_variable/requirements/standard_layout.cc
+++ b/tests/libstdc++-tests/condition_variable/requirements/standard_layout.cc
@@ -1,0 +1,34 @@
+// { dg-do compile { target c++11 } }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/condition_variable.hpp"
+#include <testsuite_common_types.h>
+
+void test01()
+{
+  __gnu_test::standard_layout test;
+  test.operator()<rtpi::condition_variable>();
+}
+
+int main()
+{
+  test01();
+}

--- a/tests/libstdc++-tests/condition_variable/requirements/typedefs.cc
+++ b/tests/libstdc++-tests/condition_variable/requirements/typedefs.cc
@@ -1,0 +1,35 @@
+// { dg-do compile { target c++11 } }
+// { dg-require-gthreads "" }
+// 2009-01-28 Benjamin Kosnik <bkoz@redhat.com>
+
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/condition_variable.hpp"
+
+void test01()
+{
+  // Check for required typedefs
+  typedef rtpi::condition_variable test_type;
+  typedef test_type::native_handle_type type;
+}
+
+int main()
+{
+  test01();
+}

--- a/tests/libstdc++-tests/mutex/cons/1.cc
+++ b/tests/libstdc++-tests/mutex/cons/1.cc
@@ -1,0 +1,46 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m1;
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/cons/constexpr.cc
+++ b/tests/libstdc++-tests/mutex/cons/constexpr.cc
@@ -1,0 +1,29 @@
+// { dg-do compile { target c++11 } }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2010-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rtpi/mutex.hpp"
+#include <testsuite_common_types.h>
+
+int main()
+{
+  __gnu_test::constexpr_default_constructible test;
+  test.operator()<rtpi::mutex>();
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/dest/destructor_locked.cc
+++ b/tests/libstdc++-tests/mutex/dest/destructor_locked.cc
@@ -1,0 +1,48 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m;
+      m.lock();
+    }
+  catch (const std::system_error& e)
+    {
+      // Destroying locked mutex raises system error, or undefined.
+      // POSIX == may fail with EBUSY.
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/lock/1.cc
+++ b/tests/libstdc++-tests/mutex/lock/1.cc
@@ -1,0 +1,60 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m;
+      m.lock();
+
+      // Lock already locked mutex.
+      try
+	{
+	  // XXX Will block.
+	  // m.lock();
+	}
+      catch (const std::system_error& e)
+	{
+	  VERIFY( false );
+	}
+
+      m.unlock();
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/native_handle/1.cc
+++ b/tests/libstdc++-tests/mutex/native_handle/1.cc
@@ -1,0 +1,48 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m;
+      mutex_type::native_handle_type n = m.native_handle();
+      (void)n;
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/native_handle/typesizes.cc
+++ b/tests/libstdc++-tests/mutex/native_handle/typesizes.cc
@@ -1,0 +1,31 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rtpi/mutex.hpp"
+#include <thread/all.h>
+
+int main()
+{
+  typedef rtpi::mutex test_type;
+  __gnu_test::compare_type_to_native_type<test_type>();
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/requirements/standard_layout.cc
+++ b/tests/libstdc++-tests/mutex/requirements/standard_layout.cc
@@ -1,0 +1,34 @@
+// { dg-do compile { target c++11 } }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <testsuite_common_types.h>
+
+void test01()
+{
+  __gnu_test::standard_layout test;
+  test.operator()<rtpi::mutex>();
+}
+
+int main()
+{
+  test01();
+}

--- a/tests/libstdc++-tests/mutex/requirements/typedefs.cc
+++ b/tests/libstdc++-tests/mutex/requirements/typedefs.cc
@@ -1,0 +1,35 @@
+// { dg-do compile { target c++11 } }
+// { dg-require-gthreads "" }
+// 2008-03-18 Benjamin Kosnik <bkoz@redhat.com>
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+
+void test01()
+{
+  // Check for required typedefs
+  typedef rtpi::mutex test_type;
+  typedef test_type::native_handle_type type;
+}
+
+int main()
+{
+  test01();
+}

--- a/tests/libstdc++-tests/mutex/try_lock/1.cc
+++ b/tests/libstdc++-tests/mutex/try_lock/1.cc
@@ -1,0 +1,49 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m;
+      bool b = m.try_lock();
+      VERIFY( b );
+      m.unlock();
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/try_lock/2.cc
+++ b/tests/libstdc++-tests/mutex/try_lock/2.cc
@@ -1,0 +1,64 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <thread>
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      mutex_type m;
+      m.lock();
+      bool b;
+
+      std::thread t([&] {
+        try
+          {
+            b = m.try_lock();
+          }
+        catch (const std::system_error& e)
+          {
+            VERIFY( false );
+          }
+      });
+      t.join();
+      VERIFY( !b );
+
+      m.unlock();
+    }
+  catch (const std::system_error& e)
+    {
+      VERIFY( false );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/unlock/1.cc
+++ b/tests/libstdc++-tests/mutex/unlock/1.cc
@@ -1,0 +1,49 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2008-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "rtpi/mutex.hpp"
+#include <system_error>
+#include <testsuite_hooks.h>
+
+int main()
+{
+  typedef rtpi::mutex mutex_type;
+
+  try 
+    {
+      // Unlock mutex that hasn't been locked.
+      mutex_type m;
+      m.unlock();
+    }
+  catch (const std::system_error& e)
+    {
+      // POSIX == EPERM
+      VERIFY( true );
+    }
+  catch (...)
+    {
+      VERIFY( false );
+    }
+
+  return 0;
+}

--- a/tests/libstdc++-tests/mutex/unlock/2.cc
+++ b/tests/libstdc++-tests/mutex/unlock/2.cc
@@ -1,0 +1,41 @@
+// { dg-do run }
+// { dg-additional-options "-pthread" { target pthread } }
+// { dg-require-effective-target c++11 }
+// { dg-require-gthreads "" }
+
+// Copyright (C) 2015-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+#include "rtpi/mutex.hpp"
+#include <thread>
+
+using mutex_type = rtpi::mutex;
+
+mutex_type m;
+
+void f()
+{
+  std::lock_guard<mutex_type> l(m);
+}
+
+int main()
+{
+  std::thread t1(f);
+  std::thread t2(f);
+  t1.join();
+  t2.join();
+}

--- a/tests/libstdc++-tests/util/slow_clock.h
+++ b/tests/libstdc++-tests/util/slow_clock.h
@@ -1,0 +1,41 @@
+// -*- C++ -*-
+
+// Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 3, or (at
+// your option) any later version.
+
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+// A clock that ticks at a third of the speed of system_clock that can be used
+// to ensure that functions with timeouts don't erroneously return early.
+
+#include <chrono>
+
+namespace __gnu_test
+{
+struct slow_clock
+{
+  using rep = std::chrono::system_clock::rep;
+  using period = std::chrono::system_clock::period;
+  using duration = std::chrono::system_clock::duration;
+  using time_point = std::chrono::time_point<slow_clock, duration>;
+  static constexpr bool is_steady = false;
+
+  static time_point now()
+  {
+    auto real = std::chrono::system_clock::now();
+    return time_point{real.time_since_epoch() / 3};
+  }
+};
+}

--- a/tests/libstdc++-tests/util/testsuite_common_types.h
+++ b/tests/libstdc++-tests/util/testsuite_common_types.h
@@ -1,0 +1,585 @@
+// -*- C++ -*-
+// typelist for the C++ library testsuite.
+//
+// Copyright (C) 2005-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef _TESTSUITE_COMMON_TYPES_H
+#define _TESTSUITE_COMMON_TYPES_H 1
+
+#include <ext/typelist.h>
+
+#include <ext/new_allocator.h>
+#include <ext/malloc_allocator.h>
+#include <ext/mt_allocator.h>
+#include <ext/bitmap_allocator.h>
+#include <ext/pool_allocator.h>
+
+#include <algorithm>
+
+#include <vector>
+#include <list>
+#include <deque>
+#include <string>
+#include <limits>
+
+#include <map>
+#include <set>
+
+#if __cplusplus >= 201103L
+#include <atomic>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+namespace unord = std;
+#else
+#include <tr1/unordered_map>
+#include <tr1/unordered_set>
+namespace unord = std::tr1;
+#endif
+
+namespace __gnu_test
+{
+  using __gnu_cxx::typelist::null_type;
+  using __gnu_cxx::typelist::node;
+  using __gnu_cxx::typelist::transform;
+  using __gnu_cxx::typelist::append;
+
+#if __cplusplus >= 201103L
+
+  struct constexpr_comparison_eq_ne
+  {
+    template<typename _Tp1, typename _Tp2 = _Tp1>
+      void
+      operator()()
+      {
+	static_assert(_Tp1() == _Tp2(), "eq");
+	static_assert(!(_Tp1() != _Tp2()), "ne");
+      }
+  };
+
+  struct constexpr_comparison_operators
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	static_assert(!(_Tp() < _Tp()), "less");
+	static_assert(_Tp() <= _Tp(), "leq");
+	static_assert(!(_Tp() > _Tp()), "more");
+	static_assert(_Tp() >= _Tp(), "meq");
+	static_assert(_Tp() == _Tp(), "eq");
+	static_assert(!(_Tp() != _Tp()), "ne");
+      }
+  };
+
+  struct has_trivial_cons_dtor
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    typedef std::is_trivially_default_constructible<_Tp> ctor_p;
+	    static_assert(ctor_p::value, "default constructor not trivial");
+
+	    typedef std::is_trivially_destructible<_Tp> dtor_p;
+	    static_assert(dtor_p::value, "destructor not trivial");
+	  }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  struct has_trivial_dtor
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    typedef std::is_trivially_destructible<_Tp> dtor_p;
+	    static_assert(dtor_p::value, "destructor not trivial");
+	  }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test standard layout
+  struct standard_layout
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    typedef std::is_standard_layout<_Tp> standard_layout_p;
+	    static_assert(standard_layout_p::value, "not standard_layout");
+	  }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+#endif
+
+  // Generator to test base class
+  struct has_required_base_class
+  {
+    template<typename _TBase, typename _TDerived>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    const _TDerived& obj = __a;
+	    const _TBase* base __attribute__((unused)) = &obj;
+	  }
+
+	  _TDerived __a;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test assignment operator.
+  struct assignable
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { __v1 = __v2; }
+
+	  _Tp __v1;
+	  _Tp __v2;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test default constructor.
+  struct default_constructible
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { _Tp __v __attribute__((unused)); }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test copy constructor.
+  struct copy_constructible
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { _Tp __v2(__v1); }
+
+	  _Tp __v1;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test direct initialization, single value constructor.
+  struct single_value_constructible
+  {
+    template<typename _Ttype, typename _Tvalue>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { _Ttype __v(__a); }
+
+	  _Tvalue __a;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+#if __cplusplus >= 201103L
+  // Generator to test non-explicit default constructor.
+  struct implicitly_default_constructible
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  struct Aggregate { _Tp v; };
+
+	  void __constraint()
+	  { Aggregate __v __attribute__((unused)) = { }; }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test default constructor.
+  struct constexpr_default_constructible
+  {
+    template<typename _Tp, bool _IsLitp = __is_literal_type(_Tp)>
+      struct _Concept;
+
+    // NB: _Tp must be a literal type.
+    // Have to have user-defined default ctor for this to work,
+    // or implicit default ctor must initialize all members.
+    template<typename _Tp>
+      struct _Concept<_Tp, true>
+      {
+	void __constraint()
+	{ constexpr _Tp __obj; }
+      };
+
+    // Non-literal type, declare local static and verify no
+    // constructors generated for _Tp within the translation unit.
+    template<typename _Tp>
+      struct _Concept<_Tp, false>
+      {
+	void __constraint()
+	{ static _Tp __obj; }
+      };
+
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	_Concept<_Tp> c;
+	c.__constraint();
+      }
+  };
+
+  // Generator to test defaulted default constructor.
+  struct constexpr_defaulted_default_constructible
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { constexpr _Tp __v __attribute__((unused)) { }; }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  struct constexpr_single_value_constructible
+  {
+    template<typename _Ttesttype, typename _Tvaluetype,
+	     bool _IsLitp = __is_literal_type(_Ttesttype)>
+      struct _Concept;
+
+    // NB: _Tvaluetype and _Ttesttype must be literal types.
+    // Additional constraint on _Tvaluetype needed.  Either assume
+    // user-defined default ctor as per
+    // constexpr_default_constructible and provide no initializer,
+    // provide an initializer, or assume empty-list init-able. Choose
+    // the latter.
+    template<typename _Ttesttype, typename _Tvaluetype>
+      struct _Concept<_Ttesttype, _Tvaluetype, true>
+      {
+	void __constraint()
+	{
+	  constexpr _Tvaluetype __v { };
+	  constexpr _Ttesttype __obj(__v);
+	}
+      };
+
+    template<typename _Ttesttype, typename _Tvaluetype>
+      struct _Concept<_Ttesttype, _Tvaluetype, false>
+      {
+	void __constraint()
+	{
+	  const _Tvaluetype __v { };
+	  static _Ttesttype __obj(__v);
+	}
+      };
+
+    template<typename _Ttesttype, typename _Tvaluetype>
+      void
+      operator()()
+      {
+	_Concept<_Ttesttype, _Tvaluetype> c;
+	c.__constraint();
+      }
+  };
+#endif
+
+  // Generator to test direct list initialization
+#if __cplusplus >= 201103L
+  struct direct_list_initializable
+  {
+    template<typename _Ttype, typename _Tvalue>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    _Ttype __v1 { }; // default ctor
+	    _Ttype __v2 { __a };  // single-argument ctor
+	  }
+
+	  _Tvalue __a;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+#endif
+
+  // Generator to test copy list initialization, aggregate initialization
+  struct copy_list_initializable
+  {
+    template<typename _Ttype, typename _Tvalue>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  { _Ttype __v __attribute__((unused)) = {__a}; }
+
+	  _Tvalue __a;
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test integral conversion operator
+  struct integral_convertable
+  {
+    template<typename _Ttype, typename _Tvalue>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    _Tvalue __v0(0);
+	    _Tvalue __v1(1);
+	    _Ttype __a(__v1);
+	    __v0 = __a;
+
+	    VERIFY( __v1 == __v0 );
+	  }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+  // Generator to test integral assignment operator
+  struct integral_assignable
+  {
+    template<typename _Ttype, typename _Tvalue>
+      void
+      operator()()
+      {
+	struct _Concept
+	{
+	  void __constraint()
+	  {
+	    _Tvalue __v0(0);
+	    _Tvalue __v1(1);
+	    _Ttype __a(__v0);
+	    __a = __v1;
+	    _Tvalue __vr = __a;
+
+	    VERIFY( __v1 == __vr );
+	  }
+	};
+
+	void (_Concept::*__x)() __attribute__((unused))
+	  = &_Concept::__constraint;
+      }
+  };
+
+#if __cplusplus >= 201103L
+  // Generator to test lowering requirements for compare-and-exchange.
+  template<std::memory_order _Torder>
+  struct compare_exchange_order_lowering
+  {
+    template<typename _Tp>
+      void
+      operator()()
+      {
+        std::atomic<_Tp> __x;
+        _Tp __expected = 0;
+        __x.compare_exchange_strong(__expected, 1, _Torder);
+        __x.compare_exchange_weak(__expected, 1, _Torder);
+      }
+  };
+#endif
+
+#if __cplusplus >= 201402L
+  // Check that bitmask type T supports all the required operators,
+  // with the required semantics. Check that each bitmask element
+  // has a distinct, nonzero value, and that each bitmask constant
+  // has no bits set which do not correspond to a bitmask element.
+  template<typename T>
+    constexpr bool
+    test_bitmask_values(std::initializer_list<T> elements,
+			std::initializer_list<T> constants = {})
+    {
+      const T t0{};
+
+      if (!(t0 == t0))
+	return false;
+      if (t0 != t0)
+	return false;
+
+      if (t0 & t0)
+	return false;
+      if (t0 | t0)
+	return false;
+      if (t0 ^ t0)
+	return false;
+
+      T all = t0;
+
+      for (auto t : elements)
+	{
+	  // Each bitmask element has a distinct value.
+	  if (t & all)
+	    return false;
+
+	  // Each bitmask element has a nonzero value.
+	  if (!bool(t))
+	    return false;
+
+	  // Check operators
+
+	  if (!(t == t))
+	    return false;
+	  if (t != t)
+	    return false;
+	  if (t == t0)
+	    return false;
+	  if (t == all)
+	    return false;
+
+	  if (t & t0)
+	    return false;
+	  if ((t | t0) != t)
+	    return false;
+	  if ((t ^ t0) != t)
+	    return false;
+
+	  if ((t & t) != t)
+	    return false;
+	  if ((t | t) != t)
+	    return false;
+	  if (t ^ t)
+	    return false;
+
+	  T t1 = t;
+	  if ((t1 &= t) != t)
+	    return false;
+	  if ((t1 |= t) != t)
+	    return false;
+	  if (t1 ^= t)
+	    return false;
+
+	  t1 = all;
+	  if ((t1 &= t) != (all & t))
+	    return false;
+	  t1 = all;
+	  if ((t1 |= t) != (all | t))
+	    return false;
+	  t1 = all;
+	  if ((t1 ^= t) != (all ^ t))
+	    return false;
+
+	  all |= t;
+	  if (!(all & t))
+	    return false;
+	}
+
+      for (auto t : constants)
+	{
+	  // Check that bitmask constants are composed of the bitmask elements.
+	  if ((t & all) != t)
+	    return false;
+	  if ((t | all) != all)
+	    return false;
+	}
+
+      return true;
+    }
+#endif // C++14
+
+
+} // namespace __gnu_test
+#endif

--- a/tests/libstdc++-tests/util/testsuite_hooks.h
+++ b/tests/libstdc++-tests/util/testsuite_hooks.h
@@ -1,0 +1,372 @@
+// -*- C++ -*-
+// Utility subroutines for the C++ library testsuite.
+//
+// Copyright (C) 2000-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+
+// This file provides the following:
+//
+// 1)  VERIFY()
+//
+// 2)  set_memory_limits()
+//   set_memory_limits() uses setrlimit() to restrict dynamic memory
+//   allocation.  We provide a default memory limit if none is passed by the
+//   calling application.  The argument to set_memory_limits() is the
+//   limit in megabytes (a floating-point number).  If _GLIBCXX_RES_LIMITS is
+//   not #defined before including this header, then no limiting is attempted.
+//
+// 3)  object_counter
+//   This is a POD with a static data member, object_counter::count,
+//   which starts at zero, increments on instance construction, and decrements
+//   on instance destruction.  "assert_count(n)" can be called to VERIFY()
+//   that the count equals N.
+//
+// 4)  copy_tracker, from Stephen M. Webb <stephen@bregmasoft.com>.
+//   A class with nontrivial ctor/dtor that provides the ability to track the
+//   number of copy ctors and dtors, and will throw on demand during copy.
+
+#ifndef _GLIBCXX_TESTSUITE_HOOKS_H
+#define _GLIBCXX_TESTSUITE_HOOKS_H
+
+#include <bits/c++config.h>
+#include <bits/functexcept.h>
+#include <ctime>
+#include <stdio.h>
+
+#ifdef _GLIBCXX_HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
+#ifdef stderr
+# define _VERIFY_PRINT(S, F, L, P, C) __builtin_fprintf(stderr, S, F, L, P, C)
+#else
+# define _VERIFY_PRINT(S, F, L, P, C) __builtin_printf(S, F, L, P, C)
+#endif
+
+#define VERIFY(fn)                                                      \
+  do                                                                    \
+  {                                                                     \
+    if (! (fn))								\
+      {									\
+	_VERIFY_PRINT("%s:%d: %s: Assertion '%s' failed.\n",		\
+		      __FILE__, __LINE__, __PRETTY_FUNCTION__, #fn);	\
+	__builtin_abort();						\
+      }									\
+  } while (false)
+
+#ifdef _GLIBCXX_HAVE_UNISTD_H
+# include <unistd.h>
+#else
+# define unlink(x)
+#endif
+
+#if defined __FreeBSD__ || defined __DragonFly__ || defined __NetBSD__
+# define ISO_8859(part,langTERR) #langTERR ".ISO8859-" #part
+#else
+# define ISO_8859(part,langTERR) ((part) == 15 ?\
+         #langTERR ".ISO8859-" #part "@euro" : #langTERR ".ISO8859-" #part)
+#endif
+
+#if __cplusplus < 201103L
+# define THROW(X) throw(X)
+#else
+# define THROW(X) noexcept(false)
+#endif
+
+#if _GLIBCXX_HAVE___CXA_THREAD_ATEXIT || _GLIBCXX_HAVE___CXA_THREAD_ATEXIT_IMPL
+// Correct order of thread_local destruction needs __cxa_thread_atexit_impl
+// or similar support from libc.
+# define CORRECT_THREAD_LOCAL_DTORS 1
+#endif
+
+namespace __gnu_test
+{
+  // All macros are defined in GLIBCXX_CONFIGURE_TESTSUITE and imported
+  // from c++config.h
+
+  // Set memory limits if possible, if not set to 0.
+#ifndef _GLIBCXX_RES_LIMITS
+#  define MEMLIMIT_MB 0
+#else
+# ifndef MEMLIMIT_MB
+#  define MEMLIMIT_MB 16.0
+# endif
+#endif
+  extern void
+  set_memory_limits(float __size = MEMLIMIT_MB);
+
+  extern void
+  set_file_limit(unsigned long __size);
+
+  // Check mangled name demangles (using __cxa_demangle) as expected.
+  void
+  verify_demangle(const char* mangled, const char* wanted);
+
+  // Simple callback structure for variable numbers of tests (all with
+  // same signature).  Assume all unit tests are of the signature
+  // void test01();
+  class func_callback
+  {
+  public:
+    typedef void (*test_type) (void);
+
+  private:
+    int		_M_size;
+    test_type	_M_tests[15];
+
+    func_callback&
+    operator=(const func_callback&);
+
+    func_callback(const func_callback&);
+
+  public:
+    func_callback(): _M_size(0) { }
+
+    int
+    size() const { return _M_size; }
+
+    const test_type*
+    tests() const { return _M_tests; }
+
+    void
+    push_back(test_type test)
+    {
+      _M_tests[_M_size] = test;
+      ++_M_size;
+    }
+  };
+
+
+  // Run select unit tests after setting global locale.
+  void
+  run_tests_wrapped_locale(const char*, const func_callback&);
+
+  // Run select unit tests after setting environment variables.
+  void
+  run_tests_wrapped_env(const char*, const char*, const func_callback&);
+
+  // Counting.
+  struct object_counter
+  {
+    // Specifically and glaringly-obviously marked 'signed' so that
+    // when COUNT mistakenly goes negative, we can track the patterns
+    // of deletions more easily.
+    typedef  signed int     size_type;
+    static size_type   count;
+    object_counter() { ++count; }
+    object_counter (const object_counter&) { ++count; }
+    ~object_counter() { --count; }
+  };
+
+#define assert_count(n)   VERIFY(__gnu_test::object_counter::count == n)
+
+  // A (static) class for counting copy constructors and possibly throwing an
+  // exception on a desired count.
+  class copy_constructor
+  {
+  public:
+    static unsigned int
+    count() { return count_; }
+
+    static void
+    mark_call()
+    {
+      count_++;
+      if (count_ == throw_on_)
+	std::__throw_runtime_error("copy_constructor::mark_call");
+    }
+
+    static void
+    reset()
+    {
+      count_ = 0;
+      throw_on_ = 0;
+    }
+
+    static void
+    throw_on(unsigned int count) { throw_on_ = count; }
+
+  private:
+    static unsigned int count_;
+    static unsigned int throw_on_;
+  };
+
+  // A (static) class for counting assignment operator calls and
+  // possibly throwing an exception on a desired count.
+  class assignment_operator
+  {
+  public:
+    static unsigned int
+    count() { return count_; }
+
+    static void
+    mark_call()
+    {
+      count_++;
+      if (count_ == throw_on_)
+	std::__throw_runtime_error("assignment_operator::mark_call");
+    }
+
+    static void
+    reset()
+    {
+      count_ = 0;
+      throw_on_ = 0;
+    }
+
+    static void
+    throw_on(unsigned int count) { throw_on_ = count; }
+
+  private:
+    static unsigned int count_;
+    static unsigned int throw_on_;
+  };
+
+  // A (static) class for tracking calls to an object's destructor.
+  class destructor
+  {
+  public:
+    static unsigned int
+    count() { return _M_count; }
+
+    static void
+    mark_call() { _M_count++; }
+
+    static void
+    reset() { _M_count = 0; }
+
+  private:
+    static unsigned int _M_count;
+  };
+
+  // A class of objects that can be used for validating various
+  // behaviors and guarantees of containers and algorithms defined in
+  // the standard library.
+  class copy_tracker
+  {
+  public:
+    // Creates a copy-tracking object with the given ID number.  If
+    // "throw_on_copy" is set, an exception will be thrown if an
+    // attempt is made to copy this object.
+    copy_tracker(int id = next_id_--, bool throw_on_copy = false)
+    : id_(id) , throw_on_copy_(throw_on_copy) { }
+
+    // Copy-constructs the object, marking a call to the copy
+    // constructor and forcing an exception if indicated.
+    copy_tracker(const copy_tracker& rhs)
+    : id_(rhs.id()), throw_on_copy_(rhs.throw_on_copy_)
+    {
+      if (throw_on_copy_)
+	copy_constructor::throw_on(copy_constructor::count() + 1);
+      copy_constructor::mark_call();
+    }
+
+    // Assigns the value of another object to this one, tracking the
+    // number of times this member function has been called and if the
+    // other object is supposed to throw an exception when it is
+    // copied, well, make it so.
+    copy_tracker&
+    operator=(const copy_tracker& rhs)
+    {
+      id_ = rhs.id();
+      if (rhs.throw_on_copy_)
+        assignment_operator::throw_on(assignment_operator::count() + 1);
+      assignment_operator::mark_call();
+      return *this;
+    }
+
+    ~copy_tracker()
+    { destructor::mark_call(); }
+
+    int
+    id() const { return id_; }
+
+    static void
+    reset()
+    {
+      copy_constructor::reset();
+      assignment_operator::reset();
+      destructor::reset();
+    }
+
+  private:
+    int   id_;
+    const bool  throw_on_copy_;
+    static int next_id_;
+  };
+
+  inline bool
+  operator==(const copy_tracker& lhs, const copy_tracker& rhs)
+  { return lhs.id() == rhs.id(); }
+
+  inline bool
+  operator<(const copy_tracker& lhs, const copy_tracker& rhs)
+  { return lhs.id() < rhs.id(); }
+
+  // Class for checking required type conversions, implicit and
+  // explicit for given library data structures.
+  template<typename _Container>
+    struct conversion
+    {
+      typedef typename _Container::const_iterator const_iterator;
+
+      // Implicit conversion iterator to const_iterator.
+      static void
+      iterator_to_const_iterator()
+      {
+	_Container v;
+	const_iterator i __attribute__((unused)) = const_iterator(v.begin());
+	const_iterator j __attribute__((unused)) = true ? i : v.begin();
+#if __cplusplus >= 201103L
+	const_iterator k __attribute__((unused)) { v.begin() };
+#endif
+      }
+    };
+
+  // A binary semaphore for use across multiple processes.
+  class semaphore
+  {
+  public:
+    // Creates a binary semaphore.  The semaphore is initially in the
+    // unsignaled state.
+    semaphore();
+
+    // Destroy the semaphore.
+    ~semaphore();
+
+    // Signal the semaphore.  If there are processes blocked in
+    // "wait", exactly one will be permitted to proceed.
+    void signal();
+
+    // Wait until the semaphore is signaled.
+    void wait();
+
+  private:
+    int sem_set_;
+
+    pid_t pid_;
+  };
+
+  // For use in 22_locale/time_get and time_put.
+  std::tm test_tm(int sec, int min, int hour, int mday, int mon,
+		  int year, int wday, int yday, int isdst);
+
+} // namespace __gnu_test
+
+#endif // _GLIBCXX_TESTSUITE_HOOKS_H
+

--- a/tests/libstdc++-tests/util/thread/all.h
+++ b/tests/libstdc++-tests/util/thread/all.h
@@ -1,0 +1,68 @@
+// -*- C++ -*-
+// Utilities for testing threads for the C++ library testsuite.
+//
+// Copyright (C) 2009-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef _GLIBCXX_TESTSUITE_THREAD_H
+#define _GLIBCXX_TESTSUITE_THREAD_H
+
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <thread>
+
+// C++11 only.
+namespace __gnu_test
+{
+  // Assume _Tp::native_handle_type.
+  // Check C++ to native_handle_type characteristics: size and alignment.
+  template<typename _Tp>
+    void
+    compare_type_to_native_type()
+    {
+      typedef _Tp test_type;
+
+      // Remove possible pointer type.
+      typedef typename test_type::native_handle_type native_handle;
+      // For std::thread native_handle_type is the type of its data member,
+      // for other types it's a pointer to the type of the data member.
+      typedef typename std::conditional<
+	std::is_same<test_type, std::thread>::value,
+	native_handle,
+	typename std::remove_pointer<native_handle>::type>::type native_type;
+
+      int st = sizeof(test_type);
+      int snt = sizeof(native_type);
+      int at = __alignof__(test_type);
+      int ant = __alignof__(native_type);
+      if (st != snt || at != ant)
+	{
+	  std::ostringstream s;
+	  s << std::endl;
+	  s << "size of _Tp: " << st << std::endl;
+	  s << "alignment of _Tp: " << st << std::endl;
+	  s << "size of *(_Tp::native_handle_type): " << snt << std::endl;
+	  s << "alignment of *(_Tp::native_handle_type): " << snt << std::endl;
+	  throw std::runtime_error(s.str());
+	}
+    }
+} // namespace __gnu_test
+
+#endif // _GLIBCXX_TESTSUITE_THREAD_H
+

--- a/tests/tst-condpi2-cpp.cpp
+++ b/tests/tst-condpi2-cpp.cpp
@@ -1,0 +1,225 @@
+/* Copyright (C) 2002, 2010, 2013 Free Software Foundation, Inc.
+   This file was submitted as a patch to the GNU C Library:
+     https://sourceware.org/bugzilla/show_bug.cgi?id=11588
+     https://sourceware.org/bugzilla/attachment.cgi?id=7689
+   Contributed by Darren Hart <dvhltc@us.ibm.com>
+   Based on pthread_cond_hang.c by Dinakar Guniguntala <dino@in.ibm.com>
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <error.h>
+#include <errno.h>
+#include <sched.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include "rtpi.h"
+
+#include "rtpi/mutex.hpp"
+#include "rtpi/condition_variable.hpp"
+
+#define LOW_PRIO  1
+#define MED_PRIO  2
+#define HIGH_PRIO 3
+#define MAIN_PRIO 4
+
+static rtpi::condition_variable race_var;
+static rtpi::mutex race_mut;
+
+static rtpi::condition_variable sig1, sig2, sig3;
+static rtpi::mutex m1, m2, m3;
+
+static volatile unsigned int done = 0;
+
+static void *
+low_tf (void *p)
+{
+  int err;
+
+  /* Wait for do_test to start all the threads.  */
+  std::unique_lock<rtpi::mutex> m1_ul(m1);
+  sig1.wait(m1_ul);
+
+  std::unique_lock<rtpi::mutex> race_ul(race_mut);
+
+  puts ("low_tf: locked");
+
+  std::unique_lock<rtpi::mutex> m2_ul(m2, std::defer_lock);
+  /* Signal the high_tf that we have the race_mut, it will preempt us until it
+   * blocks on race_mut.  */
+  sig2.notify_one(m2_ul);
+
+  /* pi_cond_wait() holds the cond_lock when it unlocks race_mut.  high_tf
+     will preempt us before we can release the cond_lock.  It will signal med_tf
+     which will continue to block us after high_tf tries to block on race_var if
+     it isn't PTHREAD_PRIO_INHERIT, and the cond_lock will never be released.  */
+  race_var.wait(race_ul);
+
+  puts ("low_tf: done waiting");
+  race_ul.unlock();
+
+  return NULL;
+}
+
+static void *
+high_tf (void *p)
+{
+  int err;
+
+  std::unique_lock<rtpi::mutex> m2_ul(m2);
+  /* Wait for low_tf to take race_mut and signal us.  We will preempt low_tf
+   * until we block on race_mut below.  */
+  sig2.wait(m2_ul);
+
+  /* Wait for low_tf to release the lock as it waits on race_var.  */
+  std::unique_lock<rtpi::mutex> race_ul(race_mut);
+
+  puts ("high_tf: locked");
+
+  /* Signal the med_tf to start spinning.  */
+  std::unique_lock<rtpi::mutex> m3_ul(m3, std::defer_lock);
+  sig3.notify_one(m3_ul);
+
+  /* If the race_var isn't PTHREAD_PRIO_INHERIT, we will block on the
+     race_var cond_lock waiting for the low_tf to release it in it's
+     pi_cond_wait(&race_var, &race_mut) call.  */
+  race_var.wait(race_ul);
+
+  puts ("high_tf: done waiting");
+
+  race_ul.unlock();
+
+  done = 1;
+  return NULL;
+}
+
+static void *
+med_tf (void *p)
+{
+  int err;
+
+  std::unique_lock<rtpi::mutex> m3_ul(m3);
+  /* Wait for high_tf to signal us.  */
+  sig3.wait(m3_ul);
+
+  puts ("med_tf: spinning");
+
+  while (!done)
+          /* Busy wait to block low threads.  */;
+
+  puts ("med_tf: done spinning");
+
+  return NULL;
+}
+
+static int
+do_test (void)
+{
+  pthread_t low_thread;
+  pthread_t med_thread;
+  pthread_t high_thread;
+  struct sched_param param;
+  pthread_attr_t attr;
+  cpu_set_t cset;
+  int err;
+
+
+  /* Initialize mutexes and condvars.  */
+
+  err = pthread_attr_init (&attr);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to init pthread_attr");
+  err = pthread_attr_setinheritsched (&attr, PTHREAD_EXPLICIT_SCHED);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set attr inheritsched");
+  err = pthread_attr_setschedpolicy (&attr, SCHED_FIFO);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set attr schedpolicy");
+
+  /* Setup scheduling parameters and create threads.  */
+  param.sched_priority = MAIN_PRIO;
+  err = sched_setscheduler (0, SCHED_FIFO, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set scheduler policy");
+
+  CPU_ZERO (&cset);
+  CPU_SET (0, &cset);
+  err = sched_setaffinity (0, sizeof (cpu_set_t), &cset);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set CPU affinity");
+
+  param.sched_priority = LOW_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for low_tf");
+  err = pthread_create (&low_thread, &attr, low_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create low_tf");
+
+  param.sched_priority = MED_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for med_tf");
+  pthread_create (&med_thread, &attr, med_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create med_tf");
+
+  param.sched_priority = HIGH_PRIO;
+  err = pthread_attr_setschedparam (&attr, &param);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to set sched param for high_tf");
+  err = pthread_create (&high_thread, &attr, high_tf, (void*)NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "parent: failed to create high_tf");
+
+  /* Wait for the threads to start and block on their respective condvars.  */
+  usleep (1000);
+  std::unique_lock<rtpi::mutex> m1_ul(m1, std::defer_lock);
+  sig1.notify_one(m1_ul);
+
+  /* Wake low_tf and high_tf, allowing them to complete.  If race_var is not
+     PTHREAD_PRIO_INHERIT, low_tf will not have released the race_var cond_lock
+     and neither thread will have waited on race_var.  */
+  usleep (1000);
+  std::unique_lock<rtpi::mutex> race_ul(race_mut, std::defer_lock);
+  race_var.notify_all(race_ul);
+
+  /* Wait for threads to complete.  */
+  err = pthread_join (low_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of low_tf failed");
+  err = pthread_join (med_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of med_tf failed");
+  err = pthread_join (high_thread, (void**) NULL);
+  if (err != 0)
+    error (EXIT_FAILURE, err, "join of high_tf failed");
+
+  puts ("done");
+
+  return 0;
+}
+
+int main(void)
+{
+	do_test();
+	return 0;
+}

--- a/tests/tst-condpi2-cpp.sh
+++ b/tests/tst-condpi2-cpp.sh
@@ -1,0 +1,2 @@
+#/bin/sh
+sudo ./tst-condpi2-cpp


### PR DESCRIPTION
Adds replacements for `std::mutex` and `std::condition_variable`, creatively named `rtpi::mutex` and `rtpi::condition_variable` that wrap the rtpi primitives in a C++11-style interface. This allows users who are coming from C++ codebases more easily migrate code to using librtpi.

Additionally, add a portion of the libstdc++ test suite to aid in verifying that the behaviors match up.