### PR TITLE
rtpi: Remove redundant restrict qualifier

### DIFF
--- a/src/pi_cond.c
+++ b/src/pi_cond.c
@@ -52,7 +52,7 @@ int pi_cond_destroy(pi_cond_t *cond)
 }
 
 int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
-		      const struct timespec *restrict abstime)
+		      const struct timespec *abstime)
 {
 	int ret;
 	__u32 wait_id;

--- a/src/pi_futex.h
+++ b/src/pi_futex.h
@@ -23,7 +23,7 @@ static inline __u32 get_op(__u32 op, __u32 mod)
  * @val3:	varies by op
  */
 static inline int sys_futex(__u32 *uaddr, int op, __u32 val,
-			    const struct timespec *restrict utime,
+			    const struct timespec *utime,
 			    __u32 *uaddr2, __u32 val3)
 {
 	return syscall(SYS_futex, uaddr, op, val, utime, uaddr2, val3);
@@ -65,7 +65,7 @@ static inline int futex_unlock_pi(pi_mutex_t *mutex)
  * @mutex: PI mutex containing PI futex target
  */
 static inline int futex_wait_requeue_pi(pi_cond_t *cond, __u32 val,
-					const struct timespec *restrict utime,
+					const struct timespec *utime,
 					pi_mutex_t *mutex)
 {
 	return sys_futex(&cond->cond,

--- a/src/rtpi.h
+++ b/src/rtpi.h
@@ -59,7 +59,7 @@ int pi_cond_destroy(pi_cond_t *cond);
 int pi_cond_wait(pi_cond_t *cond, pi_mutex_t *mutex);
 
 int pi_cond_timedwait(pi_cond_t *cond, pi_mutex_t *mutex,
-		      const struct timespec *restrict abstime);
+		      const struct timespec *abstime);
 
 int pi_cond_signal(pi_cond_t *cond, pi_mutex_t *mutex);
 


### PR DESCRIPTION
The C99 'restrict' type qualifier is used in several places when
declaring a 'const struct timespec *' timeout function parameter.

However in all use cases no other function argument is of 'const
struct timespec *' type and the compiler can already infer that the
corresponding pointer will not alias.

Additionally the 'restrict' qualifier is not defined for C++ and
creates problems when using C++ linking with librtpi. Remove the
redundant 'restrict' type qualifier.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>